### PR TITLE
feat: plan画面の入力フローUX改善（P1〜P4）

### DIFF
--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -27,6 +27,7 @@
 		Sunrise,
 		Sun,
 		Moon,
+		ArrowLeft,
 		AlertCircleIcon
 	} from '@lucide/svelte';
 	import { fly, slide } from 'svelte/transition';
@@ -62,6 +63,23 @@
 	>([]);
 	let isGenerating = $state(false);
 	let generateError = $state<string | null>(null);
+
+	// あと何件で生成可能か（0 なら生成可能）
+	const remainingToGenerate = $derived(Math.max(0, 2 - locations.length));
+
+	// 詳細設定の設定済みサマリ（折りたたみ中でも状態がわかる）
+	const transportShortLabels: Record<Exclude<TransportMode, ''>, string> = {
+		transit: '電車',
+		car: '車',
+		walking: '徒歩'
+	};
+	const detailSummary = $derived(
+		[
+			transportMode ? transportShortLabels[transportMode] : null,
+			startTime || null,
+			endDestination ? '終点あり' : null
+		].filter((v): v is string => v !== null)
+	);
 
 	function removeLocation(id: string) {
 		locations = locations.filter((loc) => loc.id !== id);
@@ -104,6 +122,15 @@
 <div class="min-h-screen bg-background p-4 md:p-8">
 	<div class="mx-auto flex max-w-2xl flex-col gap-8">
 		<header class="mb-8 flex items-center gap-3" in:fly={{ y: -10, duration: 600 }}>
+			<Button
+				href="/"
+				variant="ghost"
+				size="icon"
+				aria-label="トップに戻る"
+				class="text-muted-foreground hover:text-primary"
+			>
+				<ArrowLeft />
+			</Button>
 			<div class="rounded-xl bg-primary p-2 shadow-lg">
 				<Navigation class="size-6 text-accent" />
 			</div>
@@ -175,9 +202,15 @@
 		<section class="flex flex-col gap-3">
 			<div class="ml-1 flex items-center justify-between">
 				<h2 class="text-sm font-bold text-primary">目的地リスト</h2>
-				<Badge variant="outline" class="border-primary/20 text-[10px] text-primary">
-					{locations.length} 箇所
-				</Badge>
+				{#if locations.length >= 2}
+					<Badge variant="outline" class="border-accent/30 bg-accent/10 text-[10px] text-accent">
+						{locations.length} 箇所 · 生成可能
+					</Badge>
+				{:else}
+					<Badge variant="outline" class="border-primary/20 text-[10px] text-primary">
+						{locations.length} 箇所
+					</Badge>
+				{/if}
 			</div>
 
 			{#if locations.length > 0}
@@ -194,6 +227,9 @@
 							<MapPin />
 						</Empty.EmptyMedia>
 						<Empty.EmptyTitle>まだ目的地がありません</Empty.EmptyTitle>
+						<Empty.EmptyDescription>
+							上の検索から行きたい場所を追加しましょう。2件以上でルートを生成できます。
+						</Empty.EmptyDescription>
 					</Empty.EmptyHeader>
 				</Empty.Empty>
 			{:else}
@@ -255,6 +291,13 @@
 			>
 				<ChevronDown class="size-4 transition-transform duration-200" />
 				詳細設定（任意）
+				{#if !isDetailsOpen && detailSummary.length > 0}
+					<span class="ml-auto flex flex-wrap items-center justify-end gap-1">
+						{#each detailSummary as s (s)}
+							<Badge variant="secondary" class="text-[10px] font-normal">{s}</Badge>
+						{/each}
+					</span>
+				{/if}
 			</Collapsible.Trigger>
 			<Collapsible.Content>
 				<Field.FieldGroup class="pt-3">
@@ -337,32 +380,37 @@
 			</Collapsible.Content>
 		</Collapsible.Root>
 
-		{#if locations.length >= 2}
-			<div in:fly={{ y: 20, duration: 600 }}>
-				<Button
-					onclick={generateRoute}
-					disabled={isGenerating}
-					class="group w-full rounded-2xl bg-accent py-8 text-lg font-bold text-accent-foreground shadow-xl shadow-accent/20 hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-70"
-				>
-					{#if isGenerating}
-						<Spinner data-icon="inline-start" />
-						生成中...
-					{:else}
-						<Sparkles data-icon="inline-start" class="animate-pulse" />
-						最短ルートを自動生成する
-						<Navigation
-							data-icon="inline-end"
-							class="rotate-90 transition-transform group-hover:translate-x-1"
-						/>
-					{/if}
-				</Button>
-				{#if generateError}
-					<Alert.Root variant="destructive" class="mt-2">
-						<AlertCircleIcon />
-						<Alert.Description>{generateError}</Alert.Description>
-					</Alert.Root>
+		<div
+			class="sticky bottom-0 z-10 -mx-4 mt-2 border-t border-border/50 bg-background/90 px-4 pt-3 pb-4 backdrop-blur-sm md:-mx-8 md:px-8"
+		>
+			<Button
+				onclick={generateRoute}
+				disabled={isGenerating || remainingToGenerate > 0}
+				class="group w-full rounded-2xl bg-accent py-7 text-lg font-bold text-accent-foreground shadow-xl shadow-accent/20 hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-60"
+			>
+				{#if isGenerating}
+					<Spinner data-icon="inline-start" />
+					生成中...
+				{:else}
+					<Sparkles data-icon="inline-start" class="animate-pulse" />
+					最適ルートを自動生成する
+					<Navigation
+						data-icon="inline-end"
+						class="rotate-90 transition-transform group-hover:translate-x-1"
+					/>
 				{/if}
-			</div>
-		{/if}
+			</Button>
+			{#if remainingToGenerate > 0}
+				<p class="mt-2 text-center text-xs text-muted-foreground">
+					あと {remainingToGenerate} 件の目的地を追加するとルートを生成できます
+				</p>
+			{/if}
+			{#if generateError}
+				<Alert.Root variant="destructive" class="mt-2">
+					<AlertCircleIcon />
+					<Alert.Description>{generateError}</Alert.Description>
+				</Alert.Root>
+			{/if}
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
## 概要（なぜ・何を）

plan画面（入力フロー）のUX課題4点を改善する。生成ボタンの発見性・ゴール可視化、詳細設定の状態把握、空状態のガイド、戻る導線とボタン文言を整える。UIのみの変更で生成ロジックの契約は不変。

Closes #10

## 変更内容

- **P1: 生成CTAを常時表示＋sticky化** — 従来は目的地2件以上でのみ出現していたボタンを常時表示に。2件未満は `disabled`＋「あと◯件の目的地を追加するとルートを生成できます」を表示。画面下部に `sticky bottom-0` で固定
- **P2: 詳細設定の設定済みサマリ** — Collapsibleが閉じていても、移動手段/開始時間/終点の設定状態をトリガー行にバッジ表示（「電車」「09:00」「終点あり」）
- **P3: Empty・進捗ガイド強化** — 目的地0件のEmptyに行動喚起の説明文を追加。カウントバッジを2件以上で「N 箇所 · 生成可能」＋accent色に変化
- **P4: ヘッダー戻る導線＋文言** — ヘッダー左に戻るボタン（→トップ）を追加。生成ボタン文言を「最短ルート」→「最適ルートを自動生成する」に

## 影響範囲・契約

- 変更は `src/routes/plan/+page.svelte` のみ
- `/api/route` payload・`routeResult`・時間帯トグル・PlaceCombobox・TimePicker・詳細設定の各入力・エラー文言、テーマ変数は無変更
- 生成可否の条件（2件以上）も維持（表示方法のみ変更）＝後方互換

## 検証

- [x] `pnpm check`（0エラー0警告）
- [x] `pnpm lint`（緑）
- [x] `pnpm test`（unit 2/2）
- [x] 実機で動作確認（QAエージェント + Playwright）
  - P1〜P4全項目PASS。境界(1件⇔2件)双方向の状態遷移、stickyの追従（7件・スクロール中も下部固定）、P2バッジの開閉連動、P4遷移、`/api/route` payload非回帰、375px無破綻、console/networkエラー0

## 補足（任意）

進め方: 提案 → インライン実装 → QAエージェント（strict-qa-evaluator + Playwright）で動的検証。