### PR TITLE
feat: 住所検索にアクセシブルネーム、全ページにタイトルを付与

### DIFF
--- a/src/lib/components/place-combobox.svelte
+++ b/src/lib/components/place-combobox.svelte
@@ -12,11 +12,13 @@
 
 	let {
 		id,
+		label,
 		placeholder,
 		icon: Icon,
 		onSelect
 	}: {
 		id?: string;
+		label: string;
 		placeholder: string;
 		icon: Component;
 		onSelect: (s: Suggestion) => void;
@@ -68,6 +70,7 @@
 </script>
 
 <Command.Root
+	{label}
 	shouldFilter={false}
 	class="relative h-auto w-full overflow-visible bg-transparent p-0"
 >

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,10 @@
 	});
 </script>
 
+<svelte:head>
+	<title>rootist — 行きたい場所から旅行プランを作成</title>
+</svelte:head>
+
 <div
 	class="flex h-screen flex-col items-center justify-center overflow-hidden bg-background p-8 text-center"
 >

--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -104,6 +104,10 @@
 	}
 </script>
 
+<svelte:head>
+	<title>rootist — 旅行プランをつくる</title>
+</svelte:head>
+
 <div class="min-h-screen bg-background p-4 md:p-8">
 	<div class="mx-auto flex max-w-2xl flex-col gap-8">
 		<header class="mb-8 flex items-center gap-3" in:fly={{ y: -10, duration: 600 }}>
@@ -164,6 +168,7 @@
 				{:else}
 					<PlaceCombobox
 						id="origin"
+						label="出発地"
 						icon={Home}
 						placeholder="例：自宅最寄り駅、宿泊ホテル..."
 						onSelect={(s) => (origin = { name: s.name, displayAddress: s.displayAddress })}
@@ -234,6 +239,7 @@
 				<Field.FieldDescription>同じ都道府県内のスポットを入力してください</Field.FieldDescription>
 				<PlaceCombobox
 					id="address"
+					label="行きたい場所を追加"
 					icon={MapPin}
 					placeholder="例：東京タワー、浅草寺..."
 					onSelect={(s) =>
@@ -360,6 +366,7 @@
 					</div>
 					<PlaceCombobox
 						id="endDestination"
+						label="ゴール（宿泊先など）"
 						icon={Flag}
 						placeholder="例：新宿グランドホテル..."
 						onSelect={(s) => {

--- a/src/routes/plan/result/+page.svelte
+++ b/src/routes/plan/result/+page.svelte
@@ -33,6 +33,10 @@
 	});
 </script>
 
+<svelte:head>
+	<title>rootist — あなたの1日プラン</title>
+</svelte:head>
+
 {#if result}
 	<div class="min-h-screen bg-background p-4 md:p-8">
 		<div class="mx-auto flex max-w-2xl flex-col gap-6">


### PR DESCRIPTION
## 概要（なぜ・何を）

QA（Issue #12）で記録された既存のa11y課題2件を解消する。住所検索（PlaceCombobox）のaria-labelledbyが空でスクリーンリーダーに用途が伝わらない問題と、全ページ`<title>`未設定によりアナウンサーが「untitled page」を読み上げる問題を修正。

Closes #14

## 変更内容

- `PlaceCombobox`に必須`label`propを追加し、bits-uiの`Command.Root`へ素通し（sr-onlyラベルとして`aria-labelledby`が正しく解決される）
- plan画面の3箇所に文言を設定: 「出発地」「行きたい場所を追加」「ゴール（宿泊先など）」
- landing/plan/resultの全ページに`<svelte:head><title>`を追加。Issue #12の「プラン」語彙に統一

## 影響範囲・契約

- 変更は4ファイルのみ（+18行/削除0行）: `place-combobox.svelte`、`+page.svelte`×3
- 見た目の変更なし。PlaceComboboxの既存挙動（デバウンス・キーボードナビ・選択後クリア・チップ表示/解除・Escape閉じ）、API・state・サーバ側・テーマ変数は不変

## 検証

- [x] `pnpm check`（0エラー0警告）
- [x] `pnpm lint`（緑）
- [x] `pnpm test`（unit 2/2・e2e 1/1）
- [x] 実機で動作確認（QAエージェント×Playwright、イテレーション1でPASS）
  - アクセシブルネーム3箇所を`getByRole('combobox', {name})`で取得成功、sr-onlyラベルの非表示を実測（1×1px, clip:rect(0,0,0,0)）確認
  - 3ページのタイトル設定、`#svelte-announcer`遷移後テキストに「untitled page」が出ないことを確認
  - resultは`page.route()`モックでGemini実API非依存に検証、`routeResult`未設定時のリダイレクトでもtitleが空にならないことも確認
  - 非回帰6項目（デバウンス/選択/チップ解除/Escape/CTA有効化/ゴールキャンセル）全PASS

## 補足（任意）

dev-loopスキルによる3エージェント自動開発ループ。Sprint Contract交渉はRev.2で承認（QAがgrepの位置依存検出漏れを2回とも実コードで裏取りし、Rev.1を差し戻し）。実装は1イテレーションでQA PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)