### PR TITLE
fix: Places APIのregionCodeで地域文脈を付与し主要ランドマークを候補に含める

### DIFF
--- a/src/routes/api/places/+server.ts
+++ b/src/routes/api/places/+server.ts
@@ -40,7 +40,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			'Content-Type': 'application/json',
 			'X-Goog-Api-Key': env.GOOGLE_MAPS_API_KEY
 		},
-		body: JSON.stringify({ input: query, languageCode: 'ja' })
+		body: JSON.stringify({ input: query, languageCode: 'ja', regionCode: 'JP' })
 	});
 
 	if (!res.ok) {


### PR DESCRIPTION
## 🤔 なぜ（目的）

`/api/places`（Google Places Autocomplete）に地域文脈が渡っておらず、「東京」のような曖昧な短いクエリでは東京タワーのような主要ランドマークが候補に出てこないことがあった。2026-05-02の都道府県絞り込み廃止（`e9d0dd0`）の副作用。

Closes #18

## 🎯 何を（変更の要約）

- 「東京」で検索すると東京タワーが候補に含まれるようになった（従来は東京ドーム/東京ビッグサイト/東京駅/東京ディズニーシーの4件のみで漏れていた）

## 🛠️ どうやって（実装アプローチ）

Google Places Autocompleteのリクエストbodyに `regionCode: 'JP'` を1行追加した（`src/routes/api/places/+server.ts`）。

- 都道府県選択UIの復活は選択肢から外した。過去にUXの障壁として意図的に廃止した経緯があり、issueでも明示的に不採用としている
- `regionCode`は結果の**バイアス**であり**除外**ではない点に注意。`locationBias`（座標範囲による強いバイアス）と違い、ISO国コード単位の弱めの重み付けのため、ユーザー操作を増やさずに地域文脈だけ与えられる
- `locationBias`や`includedPrimaryTypes`の追加は今回のスコープ外とした。まず`regionCode`単体で効果が出るかを確認する方針とし、実測で十分な効果を確認できた（検証欄参照）

## ⚠️ 影響範囲・契約

- レスポンス形状（`{ suggestions: [{ placeId, name, displayAddress }] }`）は不変
- `EXCLUDED_TYPES`フィルタ、2文字未満クエリの早期リターン、エラーハンドリングは無変更
- 呼び出し側（`place-combobox.svelte`、`plan/+page.svelte`）は無変更

## ✅ 検証

- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm lint` — 変更対象ファイルは通過（`.claude/launch.json`は本PR範囲外の未追跡ファイルによる無関係の警告）
- [x] `pnpm test` — unit 2 passed / e2e 1 passed
- [x] 実機確認（curl、開発サーバーに対して実行）
  - 「東京」を3回実行、毎回`東京タワー`が候補に含まれることを確認
  - 「大阪」「京都」「横浜」でも駅・アリーナ等の主要スポットが候補に含まれることを確認
  - 2文字未満クエリ（`"東"`）は引き続き空配列
  - `EXCLUDED_TYPES`（行政区分単体）の挙動に回帰なし
  - レスポンスのキーは`displayAddress`/`name`/`placeId`の3つのまま

## 📝 補足

- `.dev-loop/20260802-places-region-bias/`にspec/sprint_contractの実装記録あり