### PR TITLE
chore: Dependabotによる依存関係の自動更新を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## 🤔 なぜ（目的）

依存関係に脆弱性が出ても、現状それに気づく手段が無い。予防的なセキュリティ対策として、脆弱性の検知と依存関係の最新化を自動化する。

Closes #21

## 🎯 何を（変更の要約）

- 依存関係に既知の脆弱性が見つかった場合、Dependabotが検知しPRを起票するようになる
- 依存関係の新しいバージョンも週次で自動チェックされ、更新PRが提案されるようになる

## 🛠️ どうやって（実装アプローチ）

`.github/dependabot.yml` を新規追加。

- `package-ecosystem: npm` を指定（pnpm-lock.yamlはnpmエコシステムとしてDependabotが自動検出するため、pnpm専用の設定は不要）
- 週次（毎週月曜）でスキャン。CLAUDE.mdのConventional Commits規約に合わせ、コミットメッセージprefixは `chore` に統一
- minor/patchの更新は1つのPRにグループ化し、通知過多を防ぐ。major更新（破壊的変更の可能性）は個別PRのまま残し、まとめて見逃さないようにした
- GitHub Actionsのワークフローは未導入のため、`github-actions` エコシステムの設定は含めていない（導入時に追加）

## ⚠️ 影響範囲・契約

- 既存の依存関係・ビルド設定への変更は無し。設定ファイルの追加のみ
- 既存の古い依存関係を一括更新する対応は含まない（issueの補足に明記のとおりスコープ外）

## ✅ 検証

- [x] `pnpm check` — 対象外（コード変更なし）
- [x] `pnpm lint` — 対象外（コード変更なし）
- [x] `pnpm test` — 対象外（コード変更なし）
- [ ] 実機で動作確認 — Dependabotの実行はGitHub側のスケジュール起動のため、マージ後の初回スキャンで確認する

## 📝 補足（任意）

- YAML構文は `gh` /GitHub側のDependabot設定バリデーションに準拠した標準形式