### PR TITLE
ci: PR作成時にcheck/lint/testを自動実行するCIを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -19,9 +19,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -31,9 +31,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"packageManager": "pnpm@10.25.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/routes/api/places/+server.ts
+++ b/src/routes/api/places/+server.ts
@@ -34,6 +34,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		return json({ suggestions: [] });
 	}
 
+	if (!env.GOOGLE_MAPS_API_KEY) {
+		error(500, 'GOOGLE_MAPS_API_KEY is not set');
+	}
+
 	const res = await fetch('https://places.googleapis.com/v1/places:autocomplete', {
 		method: 'POST',
 		headers: {


### PR DESCRIPTION
## 🤔 なぜ（目的）

レビュー前に `pnpm check` / `pnpm lint` / `pnpm test` を毎回手動で実行して確認するのが面倒で、実行し忘れも起こりうる。

Closes #23

## 🎯 何を（変更の要約）

- PRを作成・更新すると、型チェック・lint・testが自動実行されるようになった
- 各チェックが独立したステータスとしてPR上に表示され、失敗した項目がひと目でわかるようになった
- （副産物）`GOOGLE_MAPS_API_KEY`が未設定の環境で発生していた型エラー・潜在的な実行時不具合を修正した

## 🛠️ どうやって（実装アプローチ）

`.github/workflows/ci.yml` を新規追加し、`check` / `lint` / `test` の3ジョブを並列実行する構成にした。

- 1つの大きなジョブにまとめず3ジョブに分けたのは、「いずれかが失敗した場合、PR上でひと目で分かること」という要件のため。1ジョブだと失敗時にどのチェックが落ちたかログを開かないとわからない
- `pnpm/action-setup` がpnpmバージョンを解決できるよう、`package.json`に`packageManager: pnpm@10.25.0`（ローカル環境と同一）を追加した。ワークフロー内にバージョンをハードコードする代わりにこちらを選んだのは、`package.json`側を単一の情報源にしてローカルとCIのバージョンずれを防ぐため
- `test`ジョブのみ`playwright install --with-deps chromium`を実行。`pnpm test`はunit(Vitestのブラウザテスト)とe2e(Playwright)の両方でChromiumが必要なため
- DB接続・外部APIキーは、`pnpm build`（e2eのwebServer起動に含まれる）が環境変数無しでも成功することをローカルで確認済みのため、CI側にシークレットを設定していない
- トリガーは`pull_request`のみ。issueのスコープが「PR作成時」だったため、push時トリガーは今回は含めていない

### 追加修正: `GOOGLE_MAPS_API_KEY`の型エラー

CI導入後の初回実行で`check`ジョブが失敗した。原因は`svelte-kit sync`が`$env/dynamic/private`の型を実行時に存在する環境変数から動的生成する仕様で、`.env`ファイルが存在しないCI環境では`env.GOOGLE_MAPS_API_KEY`が`string | undefined`型になり、fetchのheadersに渡せずビルドエラーになっていたため（ローカルでは`.env`から常に読み込まれるため`string`型になり気づけなかった）。

このバグはCI設定自体の問題ではなく、`.env`が無いあらゆる環境（本番含む）で今後発生しうる既存の型安全性の穴であり、CIを機能させる前提として`src/routes/api/places/+server.ts`に未設定時の早期リターンガードを追加して修正した（実行時に`undefined`がヘッダー値として送られる不具合も同時に防止）。スコープ拡大について本PR内で対応する方針をユーザーに確認済み。

## ⚠️ 影響範囲・契約

- CI設定と`package.json`の`packageManager`フィールド追加に加え、`/api/places`に`GOOGLE_MAPS_API_KEY`未設定時のエラーハンドリング（500エラー）を追加。既存の正常系の挙動・レスポンス形状に変更なし
- 既存のDependabotワークフロー（`dependabot.yml`）とは独立して動作する

## ✅ 検証

- [x] `pnpm check`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm install --frozen-lockfile`（CIと同じインストール方式）がローカルで成功することを確認
- [x] `pnpm build`を環境変数無しで実行し成功することを確認
- [x] `.env`ファイルを一時的に退避しCIと同条件で`pnpm check`が0エラーになることをローカルで再現・確認
- [x] 実機で動作確認 — 本PR自体のGitHub Actions実行（Checksタブ）で `check` / `lint` / `test` 全てpassすることを確認済み

## 📝 補足

- 本PRはCI導入それ自体が検証手段になっており、Checksがgreenであることが動作確認の実測記録