### PR TITLE
fix: 行きたい場所リストの項目にページ背景と区別できる背景色を付与

### DIFF
--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -275,7 +275,7 @@
 				<Item.ItemGroup class="gap-3">
 					{#each locations as loc, i (loc.id)}
 						<div in:fly={{ x: -10, duration: 400 }} out:slide>
-							<Item.Item variant="outline" size="sm">
+							<Item.Item variant="outline" size="sm" class="bg-card shadow-sm">
 								<Item.ItemMedia
 									class="size-6 rounded-full bg-primary/10 text-[10px] font-black text-primary"
 								>
@@ -328,7 +328,7 @@
 			{#if endDestination}
 				<div in:fly={{ x: -10, duration: 300 }}>
 					<Item.ItemGroup>
-						<Item.Item variant="outline" size="sm" class="border-primary/10">
+						<Item.Item variant="outline" size="sm" class="border-primary/10 bg-card shadow-sm">
 							<Item.ItemMedia class="size-6 rounded-full bg-primary/10 text-primary">
 								<Flag class="size-3" />
 							</Item.ItemMedia>


### PR DESCRIPTION
## 🤔 なぜ（目的）

`/plan`ページで目的地リストの各項目が、暖色系のページ背景とほぼ同化して見分けにくかった。

Closes #38

## 🎯 何を（変更の要約）

- 目的地リスト・終点（宿泊先など）カードが、白背景＋薄い影でページ背景から明確に分離して見えるようになった

## 🛠️ どうやって（実装アプローチ）

原因は`src/lib/components/ui/item/item.svelte`の`outline`バリアントが背景色を持たない仕様であること。同じページの出発地カード（`border-accent/20 bg-accent/5`）は個別に背景色を付与していたが、目的地リストと終点カードだけ付け忘れられていた。

- 共通コンポーネント（`item.svelte`）側の`outline`バリアント自体は変更しなかった。他の画面での利用箇所への影響を避けるため、このページの該当2箇所にのみ`bg-card shadow-sm`を追加するスコープの狭い修正にした
- 色は`bg-accent/5`のような強調色ではなく、既存の`Card.Root`（`bg-card/50`）や結果画面の目的地カード（`bg-card/80`）で使われている「card」トークンに合わせた。目的地リストは入力フォームの一部であり過度に主張させたくないため

## ⚠️ 影響範囲・契約

- 見た目のみの変更。ロジック・状態管理・APIには影響なし

## ✅ 検証

- [x] `pnpm check`
- [x] `pnpm lint`（対象ファイルのみ、無関係な既存未追跡ファイルの影響を除く）
- [x] `pnpm test`
- [x] 実機で動作確認（ブラウザで目的地を追加し、修正前後の見た目を比較）

## 📝 補足

- 終点（宿泊先など）カードも同じ原因のため合わせて修正した
