### PR TITLE
feat: プランの共有URLを発行できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: mysql://ci:ci@localhost:3306/ci
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/src/lib/components/plan-timeline.svelte
+++ b/src/lib/components/plan-timeline.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import * as Card from '$lib/components/ui/card';
+	import {
+		MapPin,
+		Clock,
+		ChevronDown,
+		Home,
+		TrainFront,
+		Car,
+		Footprints,
+		Flag
+	} from '@lucide/svelte';
+	import { fly } from 'svelte/transition';
+	import type { RouteResult } from '$lib/stores/route';
+
+	interface Props {
+		result: RouteResult;
+	}
+
+	let { result }: Props = $props();
+
+	const timeSlotLabels: Record<string, string> = {
+		morning: '朝',
+		noon: '昼',
+		night: '晩'
+	};
+</script>
+
+<div in:fly={{ y: 10, duration: 500, delay: 100 }}>
+	<Card.Root class="border-accent/20 bg-accent/10">
+		<Card.Content class="flex flex-col gap-2">
+			{#if result.transportMode}
+				<p class="flex items-center gap-1 text-xs font-medium text-accent">
+					{#if result.transportMode === 'transit'}
+						<TrainFront class="size-3" /> 電車・公共交通
+					{:else if result.transportMode === 'car'}
+						<Car class="size-3" /> 車
+					{:else if result.transportMode === 'walking'}
+						<Footprints class="size-3" /> 徒歩
+					{/if}
+				</p>
+			{/if}
+			<p class="text-sm leading-relaxed text-primary">{result.summary}</p>
+		</Card.Content>
+	</Card.Root>
+</div>
+
+<div class="flex flex-col gap-2">
+	{#if result.origin}
+		<div in:fly={{ x: -10, duration: 400, delay: 150 }}>
+			<div class="flex items-stretch gap-3">
+				<div class="flex flex-col items-center">
+					<div
+						class="flex size-8 shrink-0 items-center justify-center rounded-full bg-accent/20 text-accent"
+					>
+						<Home class="size-4" />
+					</div>
+					<div class="my-1 w-0.5 flex-1 bg-primary/20"></div>
+					<ChevronDown class="size-4 text-primary/30" />
+				</div>
+				<Card.Root class="mb-3 flex-1 border-accent/20 bg-accent/5">
+					<Card.Header>
+						<Card.Description class="text-accent">出発地</Card.Description>
+						<Card.Title class="text-primary">{result.origin.name}</Card.Title>
+						<Card.Description class="flex items-center gap-1">
+							<MapPin class="size-3 shrink-0" />
+							{result.origin.displayAddress}
+						</Card.Description>
+					</Card.Header>
+				</Card.Root>
+			</div>
+		</div>
+	{/if}
+
+	{#each result.destinations as dest, i (dest.order)}
+		<div in:fly={{ x: -10, duration: 400, delay: 150 + i * 80 }}>
+			{#if dest.travelTimeFromPrevious}
+				<div class="mb-2 ml-2 flex items-center gap-3">
+					<div class="flex w-4 flex-col items-center">
+						<div class="h-3 w-0.5 bg-primary/20"></div>
+					</div>
+					<div class="flex flex-col gap-0.5">
+						<span class="rounded-full bg-muted/50 px-3 py-1 text-xs text-muted-foreground">
+							{dest.travelTimeFromPrevious}
+						</span>
+						{#if dest.transitRoute}
+							<span class="ml-3 flex items-center gap-1 text-xs text-muted-foreground/70">
+								<TrainFront class="size-3 shrink-0" />
+								{dest.transitRoute}
+							</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+			<div class="flex items-stretch gap-3">
+				<div class="flex flex-col items-center">
+					<div
+						class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-black text-background"
+					>
+						{dest.order}
+					</div>
+					{#if i < result.destinations.length - 1 || result.endDestination}
+						<div class="my-1 w-0.5 flex-1 bg-primary/20"></div>
+						<ChevronDown class="size-4 text-primary/30" />
+					{/if}
+				</div>
+
+				<Card.Root class="mb-3 flex-1 border-primary/5 bg-card/80">
+					<Card.Header>
+						<Card.Title class="text-primary">{dest.name}</Card.Title>
+						<Card.Description class="flex items-center gap-1">
+							<MapPin class="size-3 shrink-0" />
+							{dest.displayAddress}
+						</Card.Description>
+						<Card.Action>
+							<div class="flex flex-col items-end gap-1">
+								<p class="flex items-center gap-1 text-xs font-medium text-accent">
+									<Clock class="size-3" />
+									{dest.arrivalTime} - {dest.departureTime}
+								</p>
+								{#if dest.timeSlot && timeSlotLabels[dest.timeSlot]}
+									<Badge variant="outline" class="border-accent/30 text-[10px] text-accent">
+										{timeSlotLabels[dest.timeSlot]}指定
+									</Badge>
+								{/if}
+							</div>
+						</Card.Action>
+					</Card.Header>
+					<Card.Content>
+						<p class="border-t border-border/50 pt-2 text-xs leading-relaxed text-muted-foreground">
+							{dest.description}
+						</p>
+					</Card.Content>
+				</Card.Root>
+			</div>
+		</div>
+	{/each}
+
+	{#if result.endDestination}
+		<div in:fly={{ x: -10, duration: 400, delay: 150 + result.destinations.length * 80 }}>
+			<div class="flex items-stretch gap-3">
+				<div class="flex flex-col items-center">
+					<div
+						class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/20 text-primary"
+					>
+						<Flag class="size-4" />
+					</div>
+				</div>
+				<Card.Root class="mb-3 flex-1 border-primary/10 bg-card/80">
+					<Card.Header>
+						<Card.Description>ゴール</Card.Description>
+						<Card.Title class="text-primary">{result.endDestination.name}</Card.Title>
+						<Card.Description class="flex items-center gap-1">
+							<MapPin class="size-3 shrink-0" />
+							{result.endDestination.displayAddress}
+						</Card.Description>
+					</Card.Header>
+				</Card.Root>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,3 +1,10 @@
-import { mysqlTable, serial, int } from 'drizzle-orm/mysql-core';
+import { mysqlTable, serial, int, varchar, json, timestamp } from 'drizzle-orm/mysql-core';
 
 export const user = mysqlTable('user', { id: serial('id').primaryKey(), age: int('age') });
+
+export const plans = mysqlTable('plans', {
+	id: serial('id').primaryKey(),
+	shareId: varchar('share_id', { length: 36 }).notNull().unique(),
+	data: json('data').notNull(),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});

--- a/src/routes/api/plans/+server.ts
+++ b/src/routes/api/plans/+server.ts
@@ -1,0 +1,107 @@
+import { json, error } from '@sveltejs/kit';
+import { randomUUID } from 'node:crypto';
+import { db } from '$lib/server/db';
+import { plans } from '$lib/server/db/schema';
+import type { RequestHandler } from './$types';
+import type { RouteDestination, RouteResult } from '$lib/stores/route';
+
+// 保存時に受け入れる既知フィールドのみを対象とする（任意の巨大キー混入防止）
+const DESTINATION_KEYS = [
+	'order',
+	'name',
+	'displayAddress',
+	'arrivalTime',
+	'departureTime',
+	'description',
+	'travelTimeFromPrevious',
+	'transitRoute',
+	'timeSlot'
+] as const satisfies readonly (keyof RouteDestination)[];
+
+const MAX_BODY_BYTES = 100 * 1024;
+
+function isNonEmptyString(v: unknown): v is string {
+	return typeof v === 'string' && v.length > 0;
+}
+
+function isValidDestination(d: unknown): d is RouteDestination {
+	if (!d || typeof d !== 'object') return false;
+	const rec = d as Record<string, unknown>;
+	const orderOk = typeof rec.order === 'number' || typeof rec.order === 'string';
+	return (
+		orderOk &&
+		isNonEmptyString(rec.name) &&
+		isNonEmptyString(rec.displayAddress) &&
+		isNonEmptyString(rec.arrivalTime) &&
+		isNonEmptyString(rec.departureTime)
+	);
+}
+
+function pickDestination(d: Record<string, unknown>): RouteDestination {
+	const picked = {} as Record<string, unknown>;
+	for (const key of DESTINATION_KEYS) {
+		if (key in d) picked[key] = d[key];
+	}
+	return picked as unknown as RouteDestination;
+}
+
+function pickPlace(v: unknown): { name: string; displayAddress: string } | undefined {
+	if (!v || typeof v !== 'object') return undefined;
+	const rec = v as Record<string, unknown>;
+	if (!isNonEmptyString(rec.name) || !isNonEmptyString(rec.displayAddress)) return undefined;
+	return { name: rec.name, displayAddress: rec.displayAddress };
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	const rawBody = await request.text();
+
+	if (new TextEncoder().encode(rawBody).length > MAX_BODY_BYTES) {
+		error(400, 'リクエストボディが大きすぎます');
+	}
+
+	let body: unknown;
+	try {
+		body = JSON.parse(rawBody);
+	} catch {
+		error(400, '不正なJSON形式です');
+	}
+
+	if (!body || typeof body !== 'object') {
+		error(400, '不正なリクエストです');
+	}
+
+	const rec = body as Record<string, unknown>;
+	const destinationsInput = rec.destinations;
+
+	if (!Array.isArray(destinationsInput) || destinationsInput.length === 0) {
+		error(400, 'destinations は1件以上必要です');
+	}
+
+	if (!destinationsInput.every(isValidDestination)) {
+		error(400, 'destinations の形式が不正です');
+	}
+
+	const destinations = destinationsInput.map((d) =>
+		pickDestination(d as unknown as Record<string, unknown>)
+	);
+
+	const data: RouteResult = {
+		destinations,
+		summary: isNonEmptyString(rec.summary) ? rec.summary : '',
+		origin: pickPlace(rec.origin),
+		transportMode: typeof rec.transportMode === 'string' ? rec.transportMode : null,
+		startTime: typeof rec.startTime === 'string' ? rec.startTime : null,
+		endDestination: pickPlace(rec.endDestination) ?? null
+	};
+
+	const shareId = randomUUID();
+
+	try {
+		await db.insert(plans).values({ shareId, data });
+	} catch (e) {
+		console.error('[POST /api/plans] DB insert failed:', e);
+		error(500, 'プランの保存に失敗しました');
+	}
+
+	return json({ shareId }, { status: 201 });
+};

--- a/src/routes/api/plans/+server.ts
+++ b/src/routes/api/plans/+server.ts
@@ -27,7 +27,7 @@ function isNonEmptyString(v: unknown): v is string {
 function isValidDestination(d: unknown): d is RouteDestination {
 	if (!d || typeof d !== 'object') return false;
 	const rec = d as Record<string, unknown>;
-	const orderOk = typeof rec.order === 'number' || typeof rec.order === 'string';
+	const orderOk = typeof rec.order === 'number' && Number.isFinite(rec.order) && rec.order > 0;
 	return (
 		orderOk &&
 		isNonEmptyString(rec.name) &&
@@ -35,6 +35,13 @@ function isValidDestination(d: unknown): d is RouteDestination {
 		isNonEmptyString(rec.arrivalTime) &&
 		isNonEmptyString(rec.departureTime)
 	);
+}
+
+// each_key_duplicate（plan-timeline.svelte の {#each ... (dest.order)}）を防ぐため、
+// destinations 間で order が重複していないことを検証する。
+function hasUniqueOrders(destinations: unknown[]): boolean {
+	const orders = destinations.map((d) => (d as Record<string, unknown>).order);
+	return new Set(orders).size === orders.length;
 }
 
 function pickDestination(d: Record<string, unknown>): RouteDestination {
@@ -79,6 +86,10 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	if (!destinationsInput.every(isValidDestination)) {
 		error(400, 'destinations の形式が不正です');
+	}
+
+	if (!hasUniqueOrders(destinationsInput)) {
+		error(400, 'destinations の order が重複しています');
 	}
 
 	const destinations = destinationsInput.map((d) =>

--- a/src/routes/plan/result/+page.svelte
+++ b/src/routes/plan/result/+page.svelte
@@ -3,34 +3,69 @@
 	import { resolve } from '$app/paths';
 	import { routeResult } from '$lib/stores/route';
 	import { Button } from '$lib/components/ui/button';
-	import { Badge } from '$lib/components/ui/badge';
-	import * as Card from '$lib/components/ui/card';
-	import {
-		MapPin,
-		Navigation,
-		Clock,
-		RotateCcw,
-		ChevronDown,
-		Home,
-		TrainFront,
-		Car,
-		Footprints,
-		Flag
-	} from '@lucide/svelte';
+	import PlanTimeline from '$lib/components/plan-timeline.svelte';
+	import { Navigation, RotateCcw, Share2, Check, Loader2 } from '@lucide/svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { onMount } from 'svelte';
-
-	const timeSlotLabels: Record<string, string> = {
-		morning: '朝',
-		noon: '昼',
-		night: '晩'
-	};
 
 	let result = $state($routeResult);
 
 	onMount(() => {
 		if (!result) goto(resolve('/plan'));
 	});
+
+	let shareId = $state<string | null>(null);
+	let sharing = $state(false);
+	let shareError = $state<string | null>(null);
+	let copied = $state(false);
+	let manualShareUrl = $state<string | null>(null);
+
+	function buildShareUrl(id: string) {
+		return `${window.location.origin}${resolve('/plan/share/[shareId]', { shareId: id })}`;
+	}
+
+	async function copyToClipboard(url: string) {
+		try {
+			await navigator.clipboard.writeText(url);
+			copied = true;
+			manualShareUrl = null;
+			setTimeout(() => (copied = false), 2500);
+		} catch {
+			// クリップボードAPIが使えない環境向けフォールバック: URLを手動コピーできるよう表示する
+			manualShareUrl = url;
+		}
+	}
+
+	async function handleShare() {
+		if (sharing) return;
+		shareError = null;
+
+		if (shareId) {
+			await copyToClipboard(buildShareUrl(shareId));
+			return;
+		}
+
+		if (!result) return;
+		sharing = true;
+		try {
+			const res = await fetch('/api/plans', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(result)
+			});
+			if (!res.ok) {
+				shareError = 'プランの共有に失敗しました。時間をおいて再度お試しください。';
+				return;
+			}
+			const data: { shareId: string } = await res.json();
+			shareId = data.shareId;
+			await copyToClipboard(buildShareUrl(shareId));
+		} catch {
+			shareError = 'プランの共有に失敗しました。時間をおいて再度お試しください。';
+		} finally {
+			sharing = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -50,144 +85,32 @@
 				</div>
 			</header>
 
-			<div in:fly={{ y: 10, duration: 500, delay: 100 }}>
-				<Card.Root class="border-accent/20 bg-accent/10">
-					<Card.Content class="flex flex-col gap-2">
-						{#if result.transportMode}
-							<p class="flex items-center gap-1 text-xs font-medium text-accent">
-								{#if result.transportMode === 'transit'}
-									<TrainFront class="size-3" /> 電車・公共交通
-								{:else if result.transportMode === 'car'}
-									<Car class="size-3" /> 車
-								{:else if result.transportMode === 'walking'}
-									<Footprints class="size-3" /> 徒歩
-								{/if}
-							</p>
-						{/if}
-						<p class="text-sm leading-relaxed text-primary">{result.summary}</p>
-					</Card.Content>
-				</Card.Root>
-			</div>
+			<PlanTimeline {result} />
 
-			<div class="flex flex-col gap-2">
-				{#if result.origin}
-					<div in:fly={{ x: -10, duration: 400, delay: 150 }}>
-						<div class="flex items-stretch gap-3">
-							<div class="flex flex-col items-center">
-								<div
-									class="flex size-8 shrink-0 items-center justify-center rounded-full bg-accent/20 text-accent"
-								>
-									<Home class="size-4" />
-								</div>
-								<div class="my-1 w-0.5 flex-1 bg-primary/20"></div>
-								<ChevronDown class="size-4 text-primary/30" />
-							</div>
-							<Card.Root class="mb-3 flex-1 border-accent/20 bg-accent/5">
-								<Card.Header>
-									<Card.Description class="text-accent">出発地</Card.Description>
-									<Card.Title class="text-primary">{result.origin.name}</Card.Title>
-									<Card.Description class="flex items-center gap-1">
-										<MapPin class="size-3 shrink-0" />
-										{result.origin.displayAddress}
-									</Card.Description>
-								</Card.Header>
-							</Card.Root>
-						</div>
-					</div>
+			<div class="flex flex-col gap-2" in:fade={{ duration: 400, delay: 300 }}>
+				<Button onclick={handleShare} disabled={sharing} class="w-full">
+					{#if sharing}
+						<Loader2 data-icon="inline-start" class="animate-spin" />
+						共有リンクを発行中…
+					{:else if copied}
+						<Check data-icon="inline-start" />
+						リンクをコピーしました
+					{:else}
+						<Share2 data-icon="inline-start" />
+						同行者に共有
+					{/if}
+				</Button>
+				<p class="text-center text-xs text-muted-foreground">
+					リンクを知っている人はログインなしでプランを見られます
+				</p>
+				{#if shareError}
+					<p class="text-center text-xs font-medium text-destructive">{shareError}</p>
 				{/if}
-
-				{#each result.destinations as dest, i (dest.order)}
-					<div in:fly={{ x: -10, duration: 400, delay: 150 + i * 80 }}>
-						{#if dest.travelTimeFromPrevious}
-							<div class="mb-2 ml-2 flex items-center gap-3">
-								<div class="flex w-4 flex-col items-center">
-									<div class="h-3 w-0.5 bg-primary/20"></div>
-								</div>
-								<div class="flex flex-col gap-0.5">
-									<span class="rounded-full bg-muted/50 px-3 py-1 text-xs text-muted-foreground">
-										{dest.travelTimeFromPrevious}
-									</span>
-									{#if dest.transitRoute}
-										<span class="ml-3 flex items-center gap-1 text-xs text-muted-foreground/70">
-											<TrainFront class="size-3 shrink-0" />
-											{dest.transitRoute}
-										</span>
-									{/if}
-								</div>
-							</div>
-						{/if}
-						<div class="flex items-stretch gap-3">
-							<div class="flex flex-col items-center">
-								<div
-									class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-black text-background"
-								>
-									{dest.order}
-								</div>
-								{#if i < result.destinations.length - 1 || result.endDestination}
-									<div class="my-1 w-0.5 flex-1 bg-primary/20"></div>
-									<ChevronDown class="size-4 text-primary/30" />
-								{/if}
-							</div>
-
-							<Card.Root class="mb-3 flex-1 border-primary/5 bg-card/80">
-								<Card.Header>
-									<Card.Title class="text-primary">{dest.name}</Card.Title>
-									<Card.Description class="flex items-center gap-1">
-										<MapPin class="size-3 shrink-0" />
-										{dest.displayAddress}
-									</Card.Description>
-									<Card.Action>
-										<div class="flex flex-col items-end gap-1">
-											<p class="flex items-center gap-1 text-xs font-medium text-accent">
-												<Clock class="size-3" />
-												{dest.arrivalTime} - {dest.departureTime}
-											</p>
-											{#if dest.timeSlot && timeSlotLabels[dest.timeSlot]}
-												<Badge variant="outline" class="border-accent/30 text-[10px] text-accent">
-													{timeSlotLabels[dest.timeSlot]}指定
-												</Badge>
-											{/if}
-										</div>
-									</Card.Action>
-								</Card.Header>
-								<Card.Content>
-									<p
-										class="border-t border-border/50 pt-2 text-xs leading-relaxed text-muted-foreground"
-									>
-										{dest.description}
-									</p>
-								</Card.Content>
-							</Card.Root>
-						</div>
-					</div>
-				{/each}
-
-				{#if result.endDestination}
-					<div in:fly={{ x: -10, duration: 400, delay: 150 + result.destinations.length * 80 }}>
-						<div class="flex items-stretch gap-3">
-							<div class="flex flex-col items-center">
-								<div
-									class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/20 text-primary"
-								>
-									<Flag class="size-4" />
-								</div>
-							</div>
-							<Card.Root class="mb-3 flex-1 border-primary/10 bg-card/80">
-								<Card.Header>
-									<Card.Description>ゴール</Card.Description>
-									<Card.Title class="text-primary">{result.endDestination.name}</Card.Title>
-									<Card.Description class="flex items-center gap-1">
-										<MapPin class="size-3 shrink-0" />
-										{result.endDestination.displayAddress}
-									</Card.Description>
-								</Card.Header>
-							</Card.Root>
-						</div>
-					</div>
+				{#if manualShareUrl}
+					<p class="text-center text-xs break-all text-muted-foreground">
+						自動コピーに失敗しました。こちらのURLを手動でコピーしてください: {manualShareUrl}
+					</p>
 				{/if}
-			</div>
-
-			<div in:fade={{ duration: 400, delay: 300 }}>
 				<Button
 					onclick={() => goto(resolve('/plan'))}
 					variant="outline"

--- a/src/routes/plan/share/[shareId]/+page.server.ts
+++ b/src/routes/plan/share/[shareId]/+page.server.ts
@@ -1,0 +1,18 @@
+import { error } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { plans } from '$lib/server/db/schema';
+import type { PageServerLoad } from './$types';
+import type { RouteResult } from '$lib/stores/route';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const [record] = await db.select().from(plans).where(eq(plans.shareId, params.shareId)).limit(1);
+
+	if (!record) {
+		error(404, '共有されたプランが見つかりません');
+	}
+
+	return {
+		result: record.data as RouteResult
+	};
+};

--- a/src/routes/plan/share/[shareId]/+page.svelte
+++ b/src/routes/plan/share/[shareId]/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { Button } from '$lib/components/ui/button';
+	import PlanTimeline from '$lib/components/plan-timeline.svelte';
+	import { Navigation, MapPin } from '@lucide/svelte';
+	import { fly } from 'svelte/transition';
+	import type { PageProps } from './$types';
+
+	let { data }: PageProps = $props();
+	let result = $derived(data.result);
+</script>
+
+<svelte:head>
+	<title>rootist — 共有されたプラン</title>
+</svelte:head>
+
+<div class="min-h-screen bg-background p-4 md:p-8">
+	<div class="mx-auto flex max-w-2xl flex-col gap-6">
+		<header class="flex items-center gap-3" in:fly={{ y: -10, duration: 600 }}>
+			<div class="rounded-xl bg-primary p-2 shadow-lg">
+				<Navigation class="size-6 text-accent" />
+			</div>
+			<div>
+				<h1 class="text-2xl font-bold text-primary">共有されたプラン</h1>
+				<p class="text-xs font-medium text-muted-foreground">最適な訪問順序と1日のスケジュール</p>
+			</div>
+		</header>
+
+		<PlanTimeline {result} />
+
+		<div class="flex flex-col gap-2 rounded-xl border border-primary/10 bg-card/80 p-4">
+			<p class="flex items-center gap-1 text-sm text-primary">
+				<MapPin class="size-4 shrink-0" />
+				自分だけの旅程を作ってみませんか？
+			</p>
+			<Button href={resolve('/plan')} class="w-full">自分もプランを作成する</Button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## 🤔 なぜ（目的）

生成したプランを同行者に共有する手段が無く、待ち合わせ場所・到着予定時刻などを伝えられなかった。

Closes #40

## 🎯 何を（変更の要約）

- `/plan/result`に「同行者に共有」ボタンが追加され、押すと共有URL（`/plan/share/<uuid>`）が発行されクリップボードにコピーされる
- そのURLを開いた人は、ログイン不要で訪問順序・到着予定時刻・出発地・ゴールを閲覧できる（編集は不可）

## 🛠️ どうやって（実装アプローチ）

- **DBスキーマ**: `plans`テーブル（`shareId` UUID/UNIQUE、`data` JSON列、`createdAt`）を新設。JSON列を選んだのは、共有ページの用途が「保存時点のスナップショットをそのまま表示する」だけで検索要件が無く、プラン形状（LLM出力起点）が今後拡張されてもマイグレーション不要にするため
- **保存タイミング**: プラン生成時の自動保存ではなく、「共有する意思を示したとき」（ボタン押下時）にのみ保存。自動保存だと条件を変えて作り直すたびに不要レコードが蓄積し、削除・一覧手段が無い現状ではプライバシー面でも意図しない永続化になるため
- **表示の共通化**: `/plan/result`のsummaryカード＋タイムライン部分を`plan-timeline.svelte`として抽出し、本人向け結果ページと同行者向け共有ページ（SSR）の両方から利用。データ取得経路が根本的に異なる（クライアントストア vs DB）ため1ページに同居させず別ルートにした
- **グレースフルデグラデーション**: DB障害時も共有ボタンのエラー表示のみに留め、プラン作成・結果表示自体は壊さない設計
- **セキュリティ**: 認証なしで誰でも書き込める公開エンドポイントのため、バリデーション（既知フィールドのみpick・サイズ上限・型/一意性チェック）とstored XSS対策（Svelteの自動エスケープに依存、`{@html}`不使用を明示）を重視。開発中にQAが「`order`重複データを送ると共有ページがハイドレーションクラッシュで全消失する」というバグを発見したため、`POST /api/plans`側で`order`の数値・一意性検証を追加して修正済み

## ⚠️ 影響範囲・契約

- 既存のプラン作成フロー（`/api/route`、`/plan/+page.svelte`、`routeResult`ストア）は無変更
- `/plan/result`の見た目・挙動は現状維持（表示部のコンポーネント抽出のみ）
- 認証・ログイン・プラン一覧機能は対象外（issue #3で別途検討）

## ✅ 検証

- [x] `pnpm check` / `pnpm lint`（変更ファイル） / `pnpm test`
- [x] Sprint Contract（`.dev-loop/20260826-plan-sharing/`）に基づき、Planner→QA契約レビュー（Rev.2まで差し戻し・条件付き承認）→実装→QA動的検証のフローで進行
- [x] QAがPlaywright MCPで動的検証: バリデーション4パターン（空/欠落/過大/malformed JSON）、stored XSS実射（alert非発火・生タグ0件を確認）、共有ボタンの多重送信防止、DB停止時の非回帰、SSR表示の実測、404
- [x] QA発見のorder重複バグを修正し、再検証で解消を確認（400で拒否・既存DoDに回帰なし）

## 📝 補足

- `.dev-loop/20260826-plan-sharing/`に仕様書・Sprint Contract・QA評価・証跡一式あり

## 📌 追記

CIの`test`ジョブが、初めて`db/index.ts`を実import する変更のため `DATABASE_URL is not set` で落ちた（SvelteKitのビルド後解析フェーズでモジュールがロードされるため）。CIワークフローに`DATABASE_URL`のダミー値を追加して解消（`mysql.createPool()`は遅延接続のため実DB無しでも問題ない）。3ジョブとも green を確認済み。
