### PR TITLE
feat: ユーザー登録・ログイン機能を追加する

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,10 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			user: { id: number; email: string } | null;
+			session: { id: string; expiresAt: Date } | null;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,37 @@
+import type { Handle } from '@sveltejs/kit';
+import { SESSION_COOKIE_NAME } from '$lib/server/auth/session';
+import { validateSessionToken } from '$lib/server/auth/session-store';
+import { setSessionCookie, deleteSessionCookie } from '$lib/server/auth/cookies';
+
+// 全リクエストでセッションCookieを検証し、locals.user / locals.session を載せる。
+// ルートガードは実装しない（本issueに保護ページは存在しない）。既存の公開エンドポイント
+// （/api/plans・/api/route・/plan/share/[shareId]等）の認可・挙動には一切影響を与えない。
+export const handle: Handle = async ({ event, resolve }) => {
+	const token = event.cookies.get(SESSION_COOKIE_NAME);
+
+	if (!token) {
+		event.locals.user = null;
+		event.locals.session = null;
+		return resolve(event);
+	}
+
+	const result = await validateSessionToken(token);
+
+	if (!result.user) {
+		// 期限切れ・不一致セッション。DB側の削除は validateSessionToken 内で完結しているため、
+		// ここではCookieだけ確実に破棄する。
+		deleteSessionCookie(event.cookies);
+		event.locals.user = null;
+		event.locals.session = null;
+		return resolve(event);
+	}
+
+	event.locals.user = result.user;
+	event.locals.session = result.session;
+
+	if (result.renewed) {
+		setSessionCookie(event.cookies, token);
+	}
+
+	return resolve(event);
+};

--- a/src/lib/server/auth/cookies.ts
+++ b/src/lib/server/auth/cookies.ts
@@ -1,0 +1,19 @@
+// セッションCookieの設定・削除を一箇所に集約する（hooks / register / login / logout で共通利用）。
+
+import type { Cookies } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import { SESSION_COOKIE_NAME, SESSION_DURATION_MS } from './session';
+
+export function setSessionCookie(cookies: Cookies, token: string): void {
+	cookies.set(SESSION_COOKIE_NAME, token, {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'lax',
+		secure: !dev,
+		maxAge: SESSION_DURATION_MS / 1000
+	});
+}
+
+export function deleteSessionCookie(cookies: Cookies): void {
+	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
+}

--- a/src/lib/server/auth/password.ts
+++ b/src/lib/server/auth/password.ts
@@ -1,0 +1,42 @@
+// パスワードハッシュ化（argon2id）とタイミング攻撃緩和用のダミー検証。
+
+import { hash, verify } from '@node-rs/argon2';
+
+// OWASP/Lucia推奨値。ハッシュ文字列にパラメータが自己記述されるため、
+// verify() 側はこのオプションを渡さなくても将来のパラメータ変更に追従できる。
+const ARGON2_OPTIONS = {
+	memoryCost: 19456,
+	timeCost: 2,
+	parallelism: 1,
+	outputLen: 32
+};
+
+export async function hashPassword(password: string): Promise<string> {
+	return hash(password, ARGON2_OPTIONS);
+}
+
+export async function verifyPassword(passwordHash: string, password: string): Promise<boolean> {
+	return verify(passwordHash, password);
+}
+
+// タイミング攻撃緩和（不変条件4: アカウント列挙の抑制）用のダミーハッシュ。
+// ログイン時にメールアドレスが存在しない場合でもこのハッシュに対してverify()を実行することで、
+// 「存在するメールで実パスワード検証にかかる時間」と「存在しないメールの応答時間」の差を縮める。
+// モジュール初期化時に一度だけ生成し使い回す（起動コストは1回のみ）。
+let dummyHashPromise: Promise<string> | null = null;
+
+function getDummyHash(): Promise<string> {
+	if (!dummyHashPromise) {
+		dummyHashPromise = hash('dummy-password-for-timing-mitigation', ARGON2_OPTIONS);
+	}
+	return dummyHashPromise;
+}
+
+/**
+ * メール不存在時に呼び出す。実際のverify()相当のコストを払うだけで、結果は常に使わない
+ * （呼び出し元は常にログイン失敗として扱う）。
+ */
+export async function verifyAgainstDummyHash(password: string): Promise<void> {
+	const dummyHash = await getDummyHash();
+	await verify(dummyHash, password).catch(() => false);
+}

--- a/src/lib/server/auth/session-store.ts
+++ b/src/lib/server/auth/session-store.ts
@@ -1,0 +1,81 @@
+// セッションのDB読み書き。判定ロジック（有効期限・延長要否）は session.ts の純粋関数に委譲する。
+
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { sessions, users } from '$lib/server/db/schema';
+import {
+	createSessionExpiry,
+	hashSessionToken,
+	isSessionExpired,
+	shouldRenewSession
+} from './session';
+
+export type AuthenticatedUser = { id: number; email: string };
+export type AuthenticatedSession = { id: string; expiresAt: Date };
+
+export type SessionValidationResult =
+	| { user: AuthenticatedUser; session: AuthenticatedSession; renewed: boolean }
+	| { user: null; session: null; renewed: false };
+
+/**
+ * ログイン成功時にセッションを新規発行する。tokenはCookieに入る生値、DBにはハッシュのみ保存する。
+ */
+export async function createSession(token: string, userId: number): Promise<AuthenticatedSession> {
+	const id = hashSessionToken(token);
+	const expiresAt = createSessionExpiry();
+	await db.insert(sessions).values({ id, userId, expiresAt });
+	return { id, expiresAt };
+}
+
+/**
+ * Cookieのトークン生値からセッションを検証する。
+ * - 該当セッションが無ければゲスト扱い
+ * - 期限切れならDBから削除しゲスト扱い
+ * - 残り期間が閾値未満ならスライド延長してDBを更新する
+ */
+export async function validateSessionToken(token: string): Promise<SessionValidationResult> {
+	const id = hashSessionToken(token);
+
+	const rows = await db
+		.select({
+			sessionId: sessions.id,
+			expiresAt: sessions.expiresAt,
+			userId: users.id,
+			email: users.email
+		})
+		.from(sessions)
+		.innerJoin(users, eq(sessions.userId, users.id))
+		.where(eq(sessions.id, id));
+
+	const row = rows[0];
+	if (!row) {
+		return { user: null, session: null, renewed: false };
+	}
+
+	if (isSessionExpired(row.expiresAt)) {
+		await db.delete(sessions).where(eq(sessions.id, id));
+		return { user: null, session: null, renewed: false };
+	}
+
+	let expiresAt = row.expiresAt;
+	let renewed = false;
+	if (shouldRenewSession(row.expiresAt)) {
+		expiresAt = createSessionExpiry();
+		await db.update(sessions).set({ expiresAt }).where(eq(sessions.id, id));
+		renewed = true;
+	}
+
+	return {
+		user: { id: row.userId, email: row.email },
+		session: { id: row.sessionId, expiresAt },
+		renewed
+	};
+}
+
+/**
+ * ログアウト・ログイン済み再アクセス無効化のためセッションをDBから削除する。
+ */
+export async function invalidateSessionToken(token: string): Promise<void> {
+	const id = hashSessionToken(token);
+	await db.delete(sessions).where(eq(sessions.id, id));
+}

--- a/src/lib/server/auth/session.test.ts
+++ b/src/lib/server/auth/session.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+	generateSessionToken,
+	hashSessionToken,
+	createSessionExpiry,
+	shouldRenewSession,
+	isSessionExpired,
+	SESSION_DURATION_MS,
+	SESSION_RENEWAL_THRESHOLD_MS
+} from './session';
+
+describe('generateSessionToken', () => {
+	it('base64urlの256bit相当のトークンを生成する', () => {
+		const token = generateSessionToken();
+		// 32バイトのbase64url（パディング無し）はおおよそ43文字
+		expect(token.length).toBeGreaterThanOrEqual(42);
+		expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+	});
+
+	it('毎回異なるトークンを生成する', () => {
+		const a = generateSessionToken();
+		const b = generateSessionToken();
+		expect(a).not.toBe(b);
+	});
+});
+
+describe('hashSessionToken', () => {
+	it('SHA-256のhex文字列（64文字）を返す', () => {
+		const hash = hashSessionToken('example-token');
+		expect(hash).toHaveLength(64);
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('同じトークンからは同じハッシュが得られる（決定的）', () => {
+		expect(hashSessionToken('same-token')).toBe(hashSessionToken('same-token'));
+	});
+
+	it('生トークンとハッシュ値が一致しない', () => {
+		const token = generateSessionToken();
+		expect(hashSessionToken(token)).not.toBe(token);
+	});
+});
+
+describe('createSessionExpiry', () => {
+	it('基準時刻から30日後を返す', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiry = createSessionExpiry(now);
+		expect(expiry.getTime() - now.getTime()).toBe(SESSION_DURATION_MS);
+	});
+});
+
+describe('shouldRenewSession', () => {
+	it('残り15日未満なら延長対象と判定する', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiresAt = new Date(now.getTime() + SESSION_RENEWAL_THRESHOLD_MS - 1);
+		expect(shouldRenewSession(expiresAt, now)).toBe(true);
+	});
+
+	it('残り15日ちょうどなら延長対象にしない', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiresAt = new Date(now.getTime() + SESSION_RENEWAL_THRESHOLD_MS);
+		expect(shouldRenewSession(expiresAt, now)).toBe(false);
+	});
+
+	it('残り30日（新規発行直後）なら延長対象にしない', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiresAt = createSessionExpiry(now);
+		expect(shouldRenewSession(expiresAt, now)).toBe(false);
+	});
+});
+
+describe('isSessionExpired', () => {
+	it('有効期限が過去なら期限切れと判定する', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiresAt = new Date(now.getTime() - 1);
+		expect(isSessionExpired(expiresAt, now)).toBe(true);
+	});
+
+	it('有効期限がちょうど現在時刻なら期限切れと判定する', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		expect(isSessionExpired(now, now)).toBe(true);
+	});
+
+	it('有効期限が未来なら期限切れではないと判定する', () => {
+		const now = new Date('2026-01-01T00:00:00Z');
+		const expiresAt = new Date(now.getTime() + 1);
+		expect(isSessionExpired(expiresAt, now)).toBe(false);
+	});
+});

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -1,0 +1,49 @@
+// セッショントークンの生成・ハッシュ化・有効期限ポリシーに関する純粋関数。
+// DB（$lib/server/db）を一切importしないため、DATABASE_URL未設定・DB未接続でも単体テストできる。
+// 実際のDB読み書きは session-store.ts に分離している。
+
+import { randomBytes, createHash } from 'node:crypto';
+
+export const SESSION_COOKIE_NAME = 'auth_session';
+
+/** セッション有効期間: 30日 */
+export const SESSION_DURATION_MS = 1000 * 60 * 60 * 24 * 30;
+
+/** 残りがこの期間未満になったらスライド延長する: 15日 */
+export const SESSION_RENEWAL_THRESHOLD_MS = 1000 * 60 * 60 * 24 * 15;
+
+/**
+ * 256bit CSPRNGのセッショントークン（生値）を生成する。この値がCookieに入る。
+ */
+export function generateSessionToken(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+/**
+ * セッショントークンをSHA-256でハッシュ化しhex文字列（64文字）にする。
+ * DBの sessions.id にはこのハッシュ値のみを保存し、生値は保存しない。
+ */
+export function hashSessionToken(token: string): string {
+	return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * 現在時刻から30日後の有効期限を計算する。
+ */
+export function createSessionExpiry(now: Date = new Date()): Date {
+	return new Date(now.getTime() + SESSION_DURATION_MS);
+}
+
+/**
+ * 有効期限が閾値（15日）未満に迫っているか判定する（スライド延長すべきか）。
+ */
+export function shouldRenewSession(expiresAt: Date, now: Date = new Date()): boolean {
+	return expiresAt.getTime() - now.getTime() < SESSION_RENEWAL_THRESHOLD_MS;
+}
+
+/**
+ * セッションが期限切れかどうかを判定する。
+ */
+export function isSessionExpired(expiresAt: Date, now: Date = new Date()): boolean {
+	return expiresAt.getTime() <= now.getTime();
+}

--- a/src/lib/server/auth/validation.test.ts
+++ b/src/lib/server/auth/validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeEmail,
+	validateEmail,
+	validatePassword,
+	EMAIL_FORMAT_MESSAGE,
+	PASSWORD_LENGTH_MESSAGE
+} from './validation';
+
+describe('normalizeEmail', () => {
+	it('trimし小文字化する', () => {
+		expect(normalizeEmail('  TEST@Example.com  ')).toBe('test@example.com');
+	});
+});
+
+describe('validateEmail', () => {
+	it('正しい形式は通す', () => {
+		expect(validateEmail('test@example.com')).toEqual({ ok: true });
+	});
+
+	it('空文字は拒否する', () => {
+		expect(validateEmail('')).toEqual({ ok: false, message: EMAIL_FORMAT_MESSAGE });
+	});
+
+	it('@がない場合は拒否する', () => {
+		expect(validateEmail('not-an-email')).toEqual({ ok: false, message: EMAIL_FORMAT_MESSAGE });
+	});
+
+	it('ドメインにピリオドがない場合は拒否する', () => {
+		expect(validateEmail('test@example')).toEqual({ ok: false, message: EMAIL_FORMAT_MESSAGE });
+	});
+
+	it('255文字を超える場合は拒否する', () => {
+		const longLocal = 'a'.repeat(250);
+		expect(validateEmail(`${longLocal}@example.com`)).toEqual({
+			ok: false,
+			message: EMAIL_FORMAT_MESSAGE
+		});
+	});
+});
+
+describe('validatePassword', () => {
+	it('8文字以上は通す', () => {
+		expect(validatePassword('password123')).toEqual({ ok: true });
+	});
+
+	it('7文字は拒否する', () => {
+		expect(validatePassword('short12')).toEqual({ ok: false, message: PASSWORD_LENGTH_MESSAGE });
+	});
+
+	it('255文字を超える場合は拒否する', () => {
+		expect(validatePassword('a'.repeat(256))).toEqual({
+			ok: false,
+			message: PASSWORD_LENGTH_MESSAGE
+		});
+	});
+
+	it('境界値: 8文字ちょうどは通す', () => {
+		expect(validatePassword('12345678')).toEqual({ ok: true });
+	});
+
+	it('境界値: 255文字ちょうどは通す', () => {
+		expect(validatePassword('a'.repeat(255))).toEqual({ ok: true });
+	});
+});

--- a/src/lib/server/auth/validation.ts
+++ b/src/lib/server/auth/validation.ts
@@ -1,0 +1,43 @@
+// 登録・ログインで共通利用するバリデーション（純粋関数のみ）。
+// DBアクセスを一切行わないため、DATABASE_URL未設定・DB未接続でも単体テストできる。
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 255;
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 255;
+
+export type ValidationResult = { ok: true } | { ok: false; message: string };
+
+export const EMAIL_FORMAT_MESSAGE = 'メールアドレスの形式が正しくありません';
+export const PASSWORD_LENGTH_MESSAGE = 'パスワードは8文字以上で入力してください';
+export const DUPLICATE_EMAIL_MESSAGE = 'このメールアドレスは既に登録されています';
+export const LOGIN_FAILURE_MESSAGE = 'メールアドレスまたはパスワードが正しくありません';
+
+/**
+ * メールアドレスをtrim + 小文字化して正規化する。
+ * DBへの保存・検索は必ずこの正規化後の値を使う（大文字違いの重複登録を防ぐため）。
+ */
+export function normalizeEmail(rawEmail: string): string {
+	return rawEmail.trim().toLowerCase();
+}
+
+/**
+ * 正規化済みメールアドレスの形式を検証する。
+ * 過剰に厳密なRFC準拠検証はせず、「名前@ドメイン.tld」程度の簡易パターンとする。
+ */
+export function validateEmail(email: string): ValidationResult {
+	if (email.length === 0 || email.length > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.test(email)) {
+		return { ok: false, message: EMAIL_FORMAT_MESSAGE };
+	}
+	return { ok: true };
+}
+
+/**
+ * パスワード強度を検証する。NIST SP 800-63Bに沿い長さのみを要求し、文字種の複雑性は強制しない。
+ */
+export function validatePassword(password: string): ValidationResult {
+	if (password.length < MIN_PASSWORD_LENGTH || password.length > MAX_PASSWORD_LENGTH) {
+		return { ok: false, message: PASSWORD_LENGTH_MESSAGE };
+	}
+	return { ok: true };
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,10 +1,31 @@
-import { mysqlTable, serial, int, varchar, json, timestamp } from 'drizzle-orm/mysql-core';
-
-export const user = mysqlTable('user', { id: serial('id').primaryKey(), age: int('age') });
+import { mysqlTable, serial, bigint, varchar, json, timestamp } from 'drizzle-orm/mysql-core';
 
 export const plans = mysqlTable('plans', {
 	id: serial('id').primaryKey(),
 	shareId: varchar('share_id', { length: 36 }).notNull().unique(),
 	data: json('data').notNull(),
 	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// issue #3: ユーザー登録・ログイン。
+// 将来拡張（未実装。issue #42/#44/#45/#46/#47で列/テーブル追加のみで対応予定）:
+// - #45: users.emailVerified 列
+// - #42: oauth_accounts テーブル ＋ passwordHash の nullable化
+// - #47: plans.userId 列
+export const users = mysqlTable('users', {
+	id: serial('id').primaryKey(),
+	// ログインID。小文字正規化済みの値のみ保存する（src/lib/server/auth/validation.ts）
+	email: varchar('email', { length: 255 }).notNull().unique(),
+	// argon2idハッシュ文字列（$argon2id$...形式）。平文パスワードは一切保存しない
+	passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+export const sessions = mysqlTable('sessions', {
+	// セッショントークンのSHA-256ハッシュ（hex 64文字）。トークン生値は保存しない
+	id: varchar('id', { length: 64 }).primaryKey(),
+	userId: bigint('user_id', { mode: 'number', unsigned: true })
+		.notNull()
+		.references(() => users.id, { onDelete: 'cascade' }),
+	expiresAt: timestamp('expires_at').notNull()
 });

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,8 @@
+import type { LayoutServerLoad } from './$types';
+
+// 全ページ共通の認証ナビ表示のため、ログインユーザーのメールアドレスをdataとして渡す。
+export const load: LayoutServerLoad = async ({ locals }) => {
+	return {
+		user: locals.user ? { email: locals.user.email } : null
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,29 @@
 <script lang="ts">
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
+	import { resolve } from '$app/paths';
+	import type { LayoutData } from './$types';
 
-	let { children } = $props();
+	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
+
+<nav
+	class="fixed top-0 right-0 z-50 flex items-center gap-3 px-3 py-2 text-xs text-muted-foreground sm:px-4"
+	aria-label="アカウント"
+>
+	{#if data.user}
+		<span class="truncate">{data.user.email}</span>
+		<form method="POST" action="/logout">
+			<button type="submit" class="text-accent underline underline-offset-2">ログアウト</button>
+		</form>
+	{:else}
+		<a href={resolve('/login')} class="text-accent underline underline-offset-2">ログイン</a>
+		<a href={resolve('/register')} class="text-accent underline underline-offset-2">新規登録</a>
+	{/if}
+</nav>
+
 {@render children()}
 
 <style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	aria-label="アカウント"
 >
 	{#if data.user}
-		<span class="truncate">{data.user.email}</span>
+		<span class="max-w-[50vw] truncate">{data.user.email}</span>
 		<form method="POST" action="/logout">
 			<button type="submit" class="text-accent underline underline-offset-2">ログアウト</button>
 		</form>

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,64 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import type { Actions, PageServerLoad } from './$types';
+import { db } from '$lib/server/db';
+import { users } from '$lib/server/db/schema';
+import {
+	normalizeEmail,
+	validateEmail,
+	validatePassword,
+	LOGIN_FAILURE_MESSAGE
+} from '$lib/server/auth/validation';
+import { verifyPassword, verifyAgainstDummyHash } from '$lib/server/auth/password';
+import { generateSessionToken } from '$lib/server/auth/session';
+import { createSession } from '$lib/server/auth/session-store';
+import { setSessionCookie } from '$lib/server/auth/cookies';
+
+// ログイン済みユーザーが /login にアクセスしたら /plan へリダイレクトする
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.user) {
+		redirect(303, '/plan');
+	}
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies }) => {
+		const formData = await request.formData();
+		const rawEmail = String(formData.get('email') ?? '');
+		const password = String(formData.get('password') ?? '');
+
+		const email = normalizeEmail(rawEmail);
+
+		// メール形式・パスワード長のフォーマット不備も、存在しないメールと同じ統一メッセージにする
+		// （不変条件4: アカウント存在推測の抑制。フォーマットエラーで応答を分岐させない）
+		const emailResult = validateEmail(email);
+		const passwordResult = validatePassword(password);
+		if (!emailResult.ok || !passwordResult.ok) {
+			await verifyAgainstDummyHash(password);
+			return fail(400, { message: LOGIN_FAILURE_MESSAGE, email: rawEmail });
+		}
+
+		const rows = await db
+			.select({ id: users.id, email: users.email, passwordHash: users.passwordHash })
+			.from(users)
+			.where(eq(users.email, email));
+		const user = rows[0];
+
+		if (!user) {
+			// タイミング攻撃緩和: メール不存在時もダミーハッシュに対してverify()を実行する
+			await verifyAgainstDummyHash(password);
+			return fail(400, { message: LOGIN_FAILURE_MESSAGE, email: rawEmail });
+		}
+
+		const valid = await verifyPassword(user.passwordHash, password);
+		if (!valid) {
+			return fail(400, { message: LOGIN_FAILURE_MESSAGE, email: rawEmail });
+		}
+
+		const token = generateSessionToken();
+		await createSession(token, user.id);
+		setSessionCookie(cookies, token);
+
+		redirect(303, '/plan');
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import * as Card from '$lib/components/ui/card';
+	import * as Field from '$lib/components/ui/field';
+	import * as Alert from '$lib/components/ui/alert';
+	import { AlertCircleIcon } from '@lucide/svelte';
+	import type { ActionData } from './$types';
+
+	let { form }: { form: ActionData } = $props();
+
+	let submitting = $state(false);
+</script>
+
+<svelte:head>
+	<title>rootist — ログイン</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center bg-background p-6">
+	<Card.Root class="w-full max-w-sm border-primary/10 bg-card/60 shadow-sm backdrop-blur-sm">
+		<Card.Header>
+			<Card.Title class="text-xl">
+				<h1>ログイン</h1>
+			</Card.Title>
+			<Card.Description>メールアドレスとパスワードでログインします。</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<form
+				method="POST"
+				use:enhance={() => {
+					submitting = true;
+					return async ({ update }) => {
+						await update();
+						submitting = false;
+					};
+				}}
+				class="flex flex-col gap-4"
+			>
+				{#if form?.message}
+					<Alert.Root variant="destructive">
+						<AlertCircleIcon />
+						<Alert.Description>{form.message}</Alert.Description>
+					</Alert.Root>
+				{/if}
+
+				<Field.Field>
+					<Field.FieldLabel for="email">メールアドレス</Field.FieldLabel>
+					<Input
+						id="email"
+						name="email"
+						type="email"
+						autocomplete="email"
+						required
+						value={form?.email ?? ''}
+					/>
+				</Field.Field>
+
+				<Field.Field>
+					<Field.FieldLabel for="password">パスワード</Field.FieldLabel>
+					<Input
+						id="password"
+						name="password"
+						type="password"
+						autocomplete="current-password"
+						required
+					/>
+				</Field.Field>
+
+				<Button type="submit" disabled={submitting} class="mt-2 w-full">
+					{submitting ? 'ログイン中…' : 'ログイン'}
+				</Button>
+			</form>
+		</Card.Content>
+		<Card.Footer class="justify-center text-sm text-muted-foreground">
+			アカウントをお持ちでない方は <a href={resolve('/register')} class="ml-1 text-accent underline"
+				>新規登録</a
+			>
+		</Card.Footer>
+	</Card.Root>
+</div>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -12,6 +12,7 @@
 	let { form }: { form: ActionData } = $props();
 
 	let submitting = $state(false);
+	let password = $state('');
 </script>
 
 <svelte:head>
@@ -33,6 +34,7 @@
 					submitting = true;
 					return async ({ update }) => {
 						await update();
+						password = '';
 						submitting = false;
 					};
 				}}
@@ -65,6 +67,7 @@
 						type="password"
 						autocomplete="current-password"
 						required
+						bind:value={password}
 					/>
 				</Field.Field>
 

--- a/src/routes/logout/+page.server.ts
+++ b/src/routes/logout/+page.server.ts
@@ -1,0 +1,21 @@
+import { redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { SESSION_COOKIE_NAME } from '$lib/server/auth/session';
+import { invalidateSessionToken } from '$lib/server/auth/session-store';
+import { deleteSessionCookie } from '$lib/server/auth/cookies';
+
+// GETアクセス（load）は / へリダイレクトする（ログアウトはPOST専用）
+export const load: PageServerLoad = async () => {
+	redirect(303, '/');
+};
+
+export const actions: Actions = {
+	default: async ({ cookies }) => {
+		const token = cookies.get(SESSION_COOKIE_NAME);
+		if (token) {
+			await invalidateSessionToken(token);
+		}
+		deleteSessionCookie(cookies);
+		redirect(303, '/');
+	}
+};

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -1,0 +1,65 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import type { Actions, PageServerLoad } from './$types';
+import { db } from '$lib/server/db';
+import { users } from '$lib/server/db/schema';
+import {
+	normalizeEmail,
+	validateEmail,
+	validatePassword,
+	DUPLICATE_EMAIL_MESSAGE
+} from '$lib/server/auth/validation';
+import { hashPassword } from '$lib/server/auth/password';
+import { generateSessionToken } from '$lib/server/auth/session';
+import { createSession } from '$lib/server/auth/session-store';
+import { setSessionCookie } from '$lib/server/auth/cookies';
+
+// ログイン済みユーザーが /register にアクセスしたら /plan へリダイレクトする
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.user) {
+		redirect(303, '/plan');
+	}
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies }) => {
+		const formData = await request.formData();
+		const rawEmail = String(formData.get('email') ?? '');
+		const password = String(formData.get('password') ?? '');
+
+		const email = normalizeEmail(rawEmail);
+
+		const emailResult = validateEmail(email);
+		if (!emailResult.ok) {
+			return fail(400, { message: emailResult.message, email: rawEmail });
+		}
+
+		const passwordResult = validatePassword(password);
+		if (!passwordResult.ok) {
+			return fail(400, { message: passwordResult.message, email: rawEmail });
+		}
+
+		const existing = await db.select({ id: users.id }).from(users).where(eq(users.email, email));
+		if (existing.length > 0) {
+			return fail(400, { message: DUPLICATE_EMAIL_MESSAGE, email: rawEmail });
+		}
+
+		const passwordHash = await hashPassword(password);
+
+		let userId: number;
+		try {
+			const [inserted] = await db.insert(users).values({ email, passwordHash }).$returningId();
+			userId = inserted.id;
+		} catch {
+			// UNIQUE制約違反（事前SELECTと登録の間のレースコンディション）を同じエラーに変換する
+			return fail(400, { message: DUPLICATE_EMAIL_MESSAGE, email: rawEmail });
+		}
+
+		// 登録成功時はそのままログイン状態にする（登録→再ログインの二度手間を課さない）
+		const token = generateSessionToken();
+		await createSession(token, userId);
+		setSessionCookie(cookies, token);
+
+		redirect(303, '/plan');
+	}
+};

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { resolve } from '$app/paths';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import * as Card from '$lib/components/ui/card';
+	import * as Field from '$lib/components/ui/field';
+	import * as Alert from '$lib/components/ui/alert';
+	import { AlertCircleIcon } from '@lucide/svelte';
+	import type { ActionData } from './$types';
+
+	let { form }: { form: ActionData } = $props();
+
+	let submitting = $state(false);
+</script>
+
+<svelte:head>
+	<title>rootist — 新規登録</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center bg-background p-6">
+	<Card.Root class="w-full max-w-sm border-primary/10 bg-card/60 shadow-sm backdrop-blur-sm">
+		<Card.Header>
+			<Card.Title class="text-xl">
+				<h1>新規登録</h1>
+			</Card.Title>
+			<Card.Description>メールアドレスとパスワードでアカウントを作成します。</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<form
+				method="POST"
+				use:enhance={() => {
+					submitting = true;
+					return async ({ update }) => {
+						await update();
+						submitting = false;
+					};
+				}}
+				class="flex flex-col gap-4"
+			>
+				{#if form?.message}
+					<Alert.Root variant="destructive">
+						<AlertCircleIcon />
+						<Alert.Description>{form.message}</Alert.Description>
+					</Alert.Root>
+				{/if}
+
+				<Field.Field>
+					<Field.FieldLabel for="email">メールアドレス</Field.FieldLabel>
+					<Input
+						id="email"
+						name="email"
+						type="email"
+						autocomplete="email"
+						required
+						value={form?.email ?? ''}
+					/>
+				</Field.Field>
+
+				<Field.Field>
+					<Field.FieldLabel for="password">パスワード</Field.FieldLabel>
+					<Input
+						id="password"
+						name="password"
+						type="password"
+						autocomplete="new-password"
+						minlength={8}
+						required
+					/>
+					<Field.FieldDescription>8文字以上で入力してください。</Field.FieldDescription>
+				</Field.Field>
+
+				<Button type="submit" disabled={submitting} class="mt-2 w-full">
+					{submitting ? '登録中…' : '新規登録'}
+				</Button>
+			</form>
+		</Card.Content>
+		<Card.Footer class="justify-center text-sm text-muted-foreground">
+			すでにアカウントをお持ちの方は <a href={resolve('/login')} class="ml-1 text-accent underline"
+				>ログイン</a
+			>
+		</Card.Footer>
+	</Card.Root>
+</div>

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -12,6 +12,7 @@
 	let { form }: { form: ActionData } = $props();
 
 	let submitting = $state(false);
+	let password = $state('');
 </script>
 
 <svelte:head>
@@ -33,6 +34,7 @@
 					submitting = true;
 					return async ({ update }) => {
 						await update();
+						password = '';
 						submitting = false;
 					};
 				}}
@@ -66,6 +68,7 @@
 						autocomplete="new-password"
 						minlength={8}
 						required
+						bind:value={password}
 					/>
 					<Field.FieldDescription>8文字以上で入力してください。</Field.FieldDescription>
 				</Field.Field>


### PR DESCRIPTION
## 🤔 なぜ（目的）

ゲスト（未登録）ユーザーのプラン生成回数を制限する計画があり、その際「登録すれば制限が緩和される」という前向きな導線の受け皿として、アカウント機構が必要だった。

Closes #3

## 🎯 何を（変更の要約）

- メールアドレスとパスワードで新規登録・ログイン・ログアウトができるようになった
- ログイン状態はページ遷移・リロード・ブラウザ再起動をまたいで保持される（Cookie、30日スライド延長）
- 右上の認証ナビでゲスト/ログイン状態が表示される

## 🛠️ どうやって（実装アプローチ）

- **セッション管理**: Cookie + DBセッション（`sessions`テーブル、トークンはSHA-256ハッシュ化して保存）方式を採用し、JWTは不採用にした。JWTは発行後の失効が困難で、「ログアウトの即時反映」「将来のパスワードリセット時の全セッション無効化」と相性が悪いため
- **パスワードハッシュ化**: 既存の`@node-rs/argon2`（argon2id、OWASP推奨パラメータ）。新規npm依存パッケージは追加していない（セッショントークンの生成・ハッシュ化もNode標準`crypto`のみ）
- **ルート**: SvelteKit Form Actionsで`/register`・`/login`・`/logout`を実装。組み込みのCSRF保護（Originヘッダ検査）をそのまま活用できるため
- **セキュリティ設計**: アカウント列挙対策（ログイン失敗時の統一エラーメッセージ、メール不存在時もダミーハッシュへの`verify()`を実行しタイミング差を緩和）、パスワードの平文非保存・非レスポンス漏洩を徹底
- **DBスキーマ**: 未使用だった`user`テーブルの雛形を廃止し、`users`（email UNIQUE）と`sessions`に作り替えた

## ⚠️ 影響範囲・契約

- 既存のプラン作成フロー（`/api/route`・`/plan`）、プラン共有（`POST /api/plans`・`/plan/share/[shareId]`）には認証を要求せず、無変更
- ルートガードは実装していない（本issueのスコープに保護ページは無い）

## ✅ 検証

- [x] `pnpm check` / `pnpm lint` / `pnpm test`
- [x] エージェント開発フロー（Planner→Sprint Contract→QA契約レビュー×2回→実装→QA動的検証×2回）で進行
- [x] QAがPlaywright MCPで動的検証: 正常系・異常系（不正メール形式・短いパスワード・重複登録・誤パスワード）、パスワード非平文・セッショントークンのハッシュ化保存・CSRF保護（本番ビルドで実測）・アカウント列挙対策、セッションのスライド延長・期限切れ削除（DB直接操作で検証）、既存機能への非回帰
- [x] イテレーション1でQAが発見した2件のバグ（エラー時のパスワード欄残留、長いメールアドレスでのナビ崩れ）を修正し、再検証でPASS

## 📝 補足

- `.dev-loop/20260828-user-auth/`に仕様書・Sprint Contract・QA評価一式あり
- Notionドキュメント（ADR-001）にも本issueの設計判断を記録済み