### PR TITLE
docs: CLAUDE.mdを現在の実装に同期する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,27 +60,37 @@ docker compose --profile prod up -d   # MySQL + prod コンテナ起動
 
 ```
 src/routes/
-├── +layout.svelte   # グローバルレイアウト（背景グラデーション）
-├── +page.svelte     # ランディングページ（/plan へ誘導）
-└── plan/
-    └── +page.svelte # 目的地入力・ルート作成ページ（メインUI）
+├── +layout.svelte        # グローバルレイアウト（背景グラデーション、認証ナビ）
+├── +layout.server.ts     # locals.user をページデータとして供給
+├── +page.svelte          # ランディングページ（/plan へ誘導）
+├── register/ login/ logout/  # 登録・ログイン・ログアウト（Better Auth、Form Actions）
+├── plan/
+│   ├── +page.svelte          # 目的地入力・ルート作成ページ（メインUI）
+│   ├── result/+page.svelte   # 生成プランの表示（本人向け、クライアントストア依存）
+│   └── share/[shareId]/      # 共有プランの閲覧ページ（同行者向け、SSR・認証不要）
+└── api/
+    ├── places/+server.ts # 住所検索（Google Places API）
+    ├── route/+server.ts  # プラン生成（Gemini API）
+    └── plans/+server.ts  # プラン保存・共有URL発行
 ```
 
-### UIコンポーネント (`src/lib/components/ui/`)
+### UIコンポーネント (`src/lib/components/`)
 
-shadcn/ui スタイルの自作コンポーネント群（bits-ui プリミティブ + tailwind-variants）:
-
-- `button`, `input`, `label`, `card`, `badge`, `separator` — 基本フォームUI
-- `item` — リストアイテム用コンポーネント群（`Item`, `ItemContent`, `ItemTitle`, `ItemDescription` など）
+- `ui/` — shadcn/ui スタイルの自作コンポーネント群（bits-ui プリミティブ + tailwind-variants）。`button` / `input` / `card` / `item` / `select` / `dialog` / `field` など
+- `place-combobox.svelte` / `plan-timeline.svelte` / `time-picker.svelte` — アプリ固有の複合コンポーネント（`plan-timeline.svelte` は `/plan/result` と `/plan/share/[shareId]` の両方でプラン表示に使用）
 
 新しいコンポーネント追加時は `tailwind-variants` で variants を定義し、`src/lib/utils.ts` の `cn()` でクラスをマージするパターンに従う。
 
 ### サーバーサイド (`src/lib/server/`)
 
+- `auth.ts` — Better Auth設定（email/password認証）
+- `auth-errors.ts` — Better Authのエラーを画面表示用の日本語メッセージに変換
 - `db/index.ts` — mysql2 + Drizzle ORM の DB 接続
-- `db/schema.ts` — テーブルスキーマ定義（Drizzle）
+- `db/schema.ts` — テーブルスキーマ定義（Better Auth標準スキーマ `user`/`session`/`account`/`verification` + `plans`）
 
-DB接続には環境変数 `DATABASE_URL` が必須。`.env` ファイルを参照。
+`src/hooks.server.ts` が全リクエストでセッションを検証し `event.locals.user` に載せる（ルートガードは無し）。
+
+DB接続には環境変数 `DATABASE_URL`、認証には `BETTER_AUTH_SECRET` / `BETTER_AUTH_URL` が必須。`.env` ファイルを参照。
 
 ### テスト分類
 
@@ -90,5 +100,7 @@ DB接続には環境変数 `DATABASE_URL` が必須。`.env` ファイルを参�
 
 ### 外部API
 
-- **OpenStreetMap Nominatim** — 住所検索（APIキー不要、1秒1リクエスト制限）
+- **Google Places API (New)** — 住所検索（`GOOGLE_MAPS_API_KEY`、`regionCode: 'JP'` で地域バイアス）
   - `plan/+page.svelte` でデバウンス350msで呼び出し
+- **Google Gemini API**（`gemini-flash-latest`） — 目的地からプラン（訪問順序・時刻スケジュール）を生成（`GEMINI_API_KEY`、REST直叩き）
+- **Better Auth** — ユーザー登録・ログイン（メール/パスワード）。`BETTER_AUTH_SECRET` / `BETTER_AUTH_URL` が必須


### PR DESCRIPTION
## 🤔 なぜ（目的）

CLAUDE.mdの外部API記載が「OpenStreetMap Nominatim」のままだったが、実際にはGoogle Places APIを使っている（issue #18でregionCode対応した際も、記述の同期漏れがあった）。ルート構成・UIコンポーネント・サーバーサイド構成も、issue #18/#40/#3/#49等の実装を経て古くなっていた。

Notionのドキュメントレビュー（Fableモデルによる第三者レビュー）で、この陳腐化が自己申告の範囲より広いことが指摘されたのがきっかけ。

## 🎯 何を（変更の要約）

- 外部APIセクションをGoogle Places API / Google Gemini API / Better Authの実態に合わせて更新
- ルート構成に`/register`・`/login`・`/logout`・`/plan/result`・`/plan/share/[shareId]`・`/api/plans`を追加
- サーバーサイド構成に`auth.ts`・`auth-errors.ts`を追加、`hooks.server.ts`の役割を追記
- UIコンポーネントの記載を実際のコンポーネント一覧に更新

## 🛠️ どうやって（実装アプローチ）

実際のコードベース（`find src/routes`、`grep`での外部API呼び出し箇所確認）を突き合わせて記述を直しただけで、コードの変更は無い。エージェント開発フローは使わず直接修正した（振る舞いの変わらないドキュメント同期作業のため）。

## ✅ 検証

- [x] `pnpm lint`（Prettier）

## 📝 補足

- `@google/generative-ai`パッケージが`dependencies`にあるが未使用（Gemini呼び出しはREST直叩き）という点は、Notion側で既知の技術的負債として記録済み。本PRのスコープ外