### PR TITLE
chore: 未使用の@google/generative-aiを削除する

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
 		"vitest-browser-svelte": "^3.0.0"
 	},
 	"dependencies": {
-		"@google/generative-ai": "^0.24.1",
 		"better-auth": "^1.7.2",
 		"mysql2": "^3.23.4"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
 
   .:
     dependencies:
-      '@google/generative-ai':
-        specifier: ^0.24.1
-        version: 0.24.1
       better-auth:
         specifier: ^1.7.2
         version: 1.7.2(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@7.3.5(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@7.3.5(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(kysely@0.29.5)(mysql2@3.23.4(@types/node@26.2.0)))(mysql2@3.23.4(@types/node@26.2.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vitest@4.1.11)
@@ -850,10 +847,6 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3683,8 +3676,6 @@ snapshots:
       '@floating-ui/utils': 0.2.12
 
   '@floating-ui/utils@0.2.12': {}
-
-  '@google/generative-ai@0.24.1': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
## 🤔 なぜ（目的）

`@google/generative-ai`が`dependencies`にあるが、Gemini呼び出しの実装（`src/routes/api/route/+server.ts`）はREST APIを直接fetchしており、このSDKは一切importされていなかった。

Closes #52

## 🎯 何を（変更の要約）

未使用の依存パッケージを削除した。挙動の変更は無い。

## 🛠️ どうやって（実装アプローチ）

`grep -rln "@google/generative-ai" src/`で使用箇所0件を確認した上で、`package.json`から削除し`pnpm install`でロックファイルを更新した。SDKに寄せる方向（REST直叩きをSDK経由に置き換える）ではなく削除を選んだ。実装済みのREST直叩きは動いており、SDK化する積極的な理由が無いため。

## ✅ 検証

- [x] `pnpm check` / `pnpm lint` / `pnpm test`