### PR TITLE
feat: 認証ナビをアバター＋ドロップダウンメニュー形式に改善する

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,7 +5,8 @@ declare global {
 		// interface Error {}
 		interface Locals {
 			// issue #49: Better Auth移行によりuser.idは文字列ID（UUID）になる
-			user: { id: string; email: string } | null;
+			// issue #54: アバター表示のためname/imageを追加（DBスキーマ変更なし、既存のBetter Auth標準フィールド）
+			user: { id: string; email: string; name: string; image: string | null } | null;
 			session: { id: string; expiresAt: Date } | null;
 		}
 		// interface PageData {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -14,7 +14,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const session = await auth.api.getSession({ headers: event.request.headers });
 
 	if (session) {
-		event.locals.user = { id: session.user.id, email: session.user.email };
+		event.locals.user = {
+			id: session.user.id,
+			email: session.user.email,
+			// issue #54: アバター表示用。DBスキーマ変更なし（Better Auth標準のuser.name/user.image）
+			name: session.user.name,
+			image: session.user.image ?? null
+		};
 		event.locals.session = { id: session.session.id, expiresAt: session.session.expiresAt };
 	} else {
 		event.locals.user = null;

--- a/src/lib/components/ui/avatar/avatar-fallback.svelte
+++ b/src/lib/components/ui/avatar/avatar-fallback.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AvatarPrimitive.FallbackProps = $props();
+</script>
+
+<AvatarPrimitive.Fallback
+	bind:ref
+	data-slot="avatar-fallback"
+	class={cn(
+		'flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/avatar/avatar-image.svelte
+++ b/src/lib/components/ui/avatar/avatar-image.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AvatarPrimitive.ImageProps = $props();
+</script>
+
+<AvatarPrimitive.Image
+	bind:ref
+	data-slot="avatar-image"
+	class={cn('aspect-square size-full rounded-full object-cover', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/avatar/avatar.svelte
+++ b/src/lib/components/ui/avatar/avatar.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Avatar as AvatarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		loadingStatus = $bindable('loading'),
+		size = 'default',
+		class: className,
+		...restProps
+	}: AvatarPrimitive.RootProps & {
+		size?: 'default' | 'sm' | 'lg';
+	} = $props();
+</script>
+
+<AvatarPrimitive.Root
+	bind:ref
+	bind:loadingStatus
+	data-slot="avatar"
+	data-size={size}
+	class={cn(
+		'group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/avatar/index.ts
+++ b/src/lib/components/ui/avatar/index.ts
@@ -1,0 +1,13 @@
+import Fallback from './avatar-fallback.svelte';
+import Image from './avatar-image.svelte';
+import Root from './avatar.svelte';
+
+export {
+	Root,
+	Image,
+	Fallback,
+	//
+	Root as Avatar,
+	Image as AvatarImage,
+	Fallback as AvatarFallback
+};

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import DropdownMenuPortal from './dropdown-menu-portal.svelte';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		sideOffset = 4,
+		align = 'start',
+		portalProps,
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DropdownMenuPortal>>;
+	} = $props();
+</script>
+
+<DropdownMenuPortal {...portalProps}>
+	<DropdownMenuPrimitive.Content
+		bind:ref
+		data-slot="dropdown-menu-content"
+		{sideOffset}
+		{align}
+		class={cn(
+			'z-50 w-(--bits-dropdown-menu-anchor-width) min-w-32 overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			className
+		)}
+		{...restProps}
+	/>
+</DropdownMenuPortal>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-group.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-group.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.GroupProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Group bind:ref data-slot="dropdown-menu-group" {...restProps} />

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		variant = 'default',
+		...restProps
+	}: DropdownMenuPrimitive.ItemProps & {
+		inset?: boolean;
+		variant?: 'default' | 'destructive';
+	} = $props();
+</script>
+
+<DropdownMenuPrimitive.Item
+	bind:ref
+	data-slot="dropdown-menu-item"
+	data-inset={inset}
+	data-variant={variant}
+	class={cn(
+		"group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,3 +1,23 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from 'tailwind-variants';
+
+	export const dropdownMenuItemVariants = tv({
+		base: "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		variants: {
+			variant: {
+				default: 'focus:bg-accent focus:text-accent-foreground',
+				destructive:
+					'text-destructive focus:bg-destructive/10 focus:text-destructive dark:focus:bg-destructive/20 *:[svg]:text-destructive'
+			}
+		},
+		defaultVariants: {
+			variant: 'default'
+		}
+	});
+
+	export type DropdownMenuItemVariant = VariantProps<typeof dropdownMenuItemVariants>['variant'];
+</script>
+
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 	import { cn } from '$lib/utils.js';
@@ -10,7 +30,7 @@
 		...restProps
 	}: DropdownMenuPrimitive.ItemProps & {
 		inset?: boolean;
-		variant?: 'default' | 'destructive';
+		variant?: DropdownMenuItemVariant;
 	} = $props();
 </script>
 
@@ -19,9 +39,6 @@
 	data-slot="dropdown-menu-item"
 	data-inset={inset}
 	data-variant={variant}
-	class={cn(
-		"group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
-		className
-	)}
+	class={cn(dropdownMenuItemVariants({ variant }), className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		inset,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		inset?: boolean;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dropdown-menu-label"
+	data-inset={inset}
+	class={cn(
+		'px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7 data-[inset]:pl-8',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-portal.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let { ...restProps }: DropdownMenuPrimitive.PortalProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Separator
+	bind:ref
+	data-slot="dropdown-menu-separator"
+	class={cn('-mx-1 my-1 h-px bg-border', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: DropdownMenuPrimitive.RootProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/dropdown-menu/index.ts
+++ b/src/lib/components/ui/dropdown-menu/index.ts
@@ -1,0 +1,28 @@
+import Content from './dropdown-menu-content.svelte';
+import Group from './dropdown-menu-group.svelte';
+import Item from './dropdown-menu-item.svelte';
+import Label from './dropdown-menu-label.svelte';
+import Portal from './dropdown-menu-portal.svelte';
+import Separator from './dropdown-menu-separator.svelte';
+import Trigger from './dropdown-menu-trigger.svelte';
+import Root from './dropdown-menu.svelte';
+
+export {
+	Content,
+	Group,
+	Item,
+	Label,
+	Portal,
+	Root,
+	Separator,
+	Trigger,
+	//
+	Root as DropdownMenu,
+	Content as DropdownMenuContent,
+	Group as DropdownMenuGroup,
+	Item as DropdownMenuItem,
+	Label as DropdownMenuLabel,
+	Portal as DropdownMenuPortal,
+	Separator as DropdownMenuSeparator,
+	Trigger as DropdownMenuTrigger
+};

--- a/src/lib/components/user-menu.svelte
+++ b/src/lib/components/user-menu.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import LogOutIcon from '@lucide/svelte/icons/log-out';
+	import * as Avatar from '$lib/components/ui/avatar/index.js';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+
+	let { user }: { user: { email: string; name: string; image: string | null } } = $props();
+
+	// issue #54: サロゲートペア対応のため charAt(0) ではなく配列スプレッドで先頭「文字」を取り出す。
+	// nameが空文字のケースは想定薄だが念のためemailにフォールバックする。
+	function firstGrapheme(value: string): string {
+		const [first] = [...value];
+		return first ?? '';
+	}
+
+	const initial = $derived((firstGrapheme(user.name) || firstGrapheme(user.email)).toUpperCase());
+
+	// email文字列から決定的にhue(0-360)を導出する単純なハッシュ（djb2）。
+	// 同一emailであれば常に同じhueになり、リロード・再ログインをまたいで一貫する。
+	function hueFromEmail(email: string): number {
+		let hash = 5381;
+		for (let i = 0; i < email.length; i++) {
+			hash = (hash * 33) ^ email.charCodeAt(i);
+		}
+		return Math.abs(hash) % 360;
+	}
+
+	const hue = $derived(hueFromEmail(user.email));
+	const fallbackStyle = $derived(
+		`background-color: oklch(0.85 0.06 ${hue}); color: oklch(0.35 0.06 ${hue});`
+	);
+
+	let logoutForm: HTMLFormElement | undefined = $state();
+</script>
+
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger
+		aria-label="アカウントメニュー"
+		class="rounded-full outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+	>
+		<Avatar.Root>
+			<Avatar.Image src={user.image ?? undefined} alt="" />
+			<Avatar.Fallback style={fallbackStyle} aria-hidden="true">{initial}</Avatar.Fallback>
+		</Avatar.Root>
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Content align="end">
+		<DropdownMenu.Group>
+			<DropdownMenu.Label class="flex flex-col gap-0.5">
+				<span class="truncate text-sm font-medium text-foreground">{user.name}</span>
+				<span class="truncate text-xs text-muted-foreground">{user.email}</span>
+			</DropdownMenu.Label>
+		</DropdownMenu.Group>
+		<DropdownMenu.Separator />
+		<DropdownMenu.Group>
+			<form method="POST" action="/logout" class="contents" bind:this={logoutForm}>
+				<DropdownMenu.Item variant="destructive" onSelect={() => logoutForm?.requestSubmit()}>
+					<LogOutIcon />
+					ログアウト
+				</DropdownMenu.Item>
+			</form>
+		</DropdownMenu.Group>
+	</DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,8 +1,11 @@
 import type { LayoutServerLoad } from './$types';
 
-// 全ページ共通の認証ナビ表示のため、ログインユーザーのメールアドレスをdataとして渡す。
+// 全ページ共通の認証ナビ表示のため、ログインユーザーの情報をdataとして渡す。
+// issue #54: アバター＋メニュー表示のためname/imageを追加（idはUIに不要なため渡さない）。
 export const load: LayoutServerLoad = async ({ locals }) => {
 	return {
-		user: locals.user ? { email: locals.user.email } : null
+		user: locals.user
+			? { email: locals.user.email, name: locals.user.name, image: locals.user.image }
+			: null
 	};
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import { resolve } from '$app/paths';
+	import UserMenu from '$lib/components/user-menu.svelte';
 	import type { LayoutData } from './$types';
 
 	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
@@ -14,10 +15,7 @@
 	aria-label="アカウント"
 >
 	{#if data.user}
-		<span class="max-w-[50vw] truncate">{data.user.email}</span>
-		<form method="POST" action="/logout">
-			<button type="submit" class="text-accent underline underline-offset-2">ログアウト</button>
-		</form>
+		<UserMenu user={data.user} />
 	{:else}
 		<a href={resolve('/login')} class="text-accent underline underline-offset-2">ログイン</a>
 		<a href={resolve('/register')} class="text-accent underline underline-offset-2">新規登録</a>


### PR DESCRIPTION
## なぜ

これまでの認証ナビは、ログイン中は常にメールアドレスとログアウトボタンがヘッダーに露出したままになっていた。一般的なUIUXでは、ログイン中の情報とログアウト操作はアバターアイコン経由のドロップダウンメニューに集約するのが標準的なパターンであり、視覚的なノイズが多く操作の意図（ログアウト）が誤操作を招きやすい状態だった。

close #54

## 何を

- ログイン時のヘッダー表示を、アバター（画像 or イニシャル＋メールアドレス由来の決定的な色のフォールバック）＋ドロップダウンメニューに置き換えた
- ドロップダウンメニュー内に名前・メールアドレス表示とログアウト操作を集約し、ログアウトは常時露出しないようにした
- ログアウトの実処理は既存の `POST /logout` Form Action をそのまま維持（`DropdownMenu.Item` の `onSelect` から `form.requestSubmit()` を呼び出す方式）

## どうやって

- `.claude/skills/shadcn-svelte` スキルの規約に従い、bits-ui ベースの `dropdown-menu` / `avatar` プリミティブを shadcn-svelte CLI で追加（`DropdownMenu.Item`/`Label` は規約通り `DropdownMenu.Group` で包む2Group構成）
- 新規 `src/lib/components/user-menu.svelte` にアバター＋メニューの複合コンポーネントを実装。フォールバック色は oklch のhueをメールアドレスから決定的に導出
- `src/hooks.server.ts` / `src/routes/+layout.server.ts` / `src/app.d.ts` を拡張し、Better Auth標準スキーマの `user.name` / `user.image` を `locals.user` に伝播（DBスキーマ変更なし）
- `src/routes/+layout.svelte` のログイン時分岐を `<UserMenu>` に置換（ゲスト時分岐・nav自体のレイアウトは無変更）

### 開発フロー

product-spec-planner → spec-implementation-generator（Sprint Contract 2回のQAレビュー往復でRev.2まで改訂）→ 実装 → strict-qa-evaluatorによる動的QA検証（Playwright実機、契約DoD 23項目全PASS）の順で進行。

QAで確認済みの主な項目:
- ログアウトが実際に `POST /logout`（form送信）で行われることをネットワークログで確認
- キーボードのみでの操作（Tab→Enter→矢印キー→Enter、Esc後のフォーカス復帰）
- アバターの色がリロード・再ログインをまたいで決定的に同一であること（oklch hue実値で確認）
- 255文字メールアドレス×375px/1440pxでの表示崩れがないこと
- `/login` `/register` `/plan` `/plan/share/[shareId]` の既存機能に非回帰がないこと
- `pnpm check` / `pnpm lint`（eslint単独実行含む）/ `pnpm test` が全て通過

### レビュアーへの補足

- devサーバー限定の既知事象として、hydration完了前にEnterキーでトリガーを押すと開→即閉じする挙動をGenerator自身が発見・自己申告済み（`waitForLoadState('networkidle')`後の追加待機で回避可能）。本番ビルドでの再現有無は未検証だが、DoD対象外・悪化方向のメカニズムがないことをQAが確認済み。
- `.dev-loop/20260828-avatar-nav-menu/` 配下に spec.md / sprint_contract.md（改訂履歴付き）/ self_evaluation.md / 検証用スクリプトを保存済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)