### PR TITLE
feat: 認証基盤にGoogleアカウントログインを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       DATABASE_URL: mysql://ci:ci@localhost:3306/ci
       BETTER_AUTH_SECRET: ci-dummy-secret-not-for-production-use-only
       BETTER_AUTH_URL: http://localhost:4173
+      GOOGLE_CLIENT_ID: ci-dummy-google-client-id
+      GOOGLE_CLIENT_SECRET: ci-dummy-google-client-secret
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/src/lib/components/google-icon.svelte
+++ b/src/lib/components/google-icon.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	// issue #42: @lucide/svelte にGoogleブランドアイコンが存在しないため、公式ブランドガイドライン
+	// 準拠の"G"ロゴSVGを自作する。lucide-svelteのアイコンコンポーネントと同じ流儀
+	// （ref/class/その他属性をsvgルートへスプレッド、固定サイズクラスは持たせない）に合わせることで、
+	// Buttonの `[&_svg:not([class*='size-'])]:size-4` 等のサイズ制御・`data-icon` 配置と協調する。
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable<SVGSVGElement | null>(null),
+		class: className,
+		...restProps
+	}: HTMLAttributes<SVGSVGElement> & { ref?: SVGSVGElement | null } = $props();
+</script>
+
+<svg
+	bind:this={ref}
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	aria-hidden="true"
+	focusable="false"
+	class={className}
+	{...restProps}
+>
+	<path
+		fill="#4285F4"
+		d="M23.49 12.27c0-.79-.07-1.54-.19-2.27H12v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.58v3h3.86c2.26-2.08 3.56-5.14 3.56-8.82z"
+	/>
+	<path
+		fill="#34A853"
+		d="M12 24c3.24 0 5.95-1.08 7.93-2.91l-3.86-3c-1.08.72-2.45 1.16-4.07 1.16-3.13 0-5.78-2.11-6.73-4.96H1.29v3.09C3.26 21.3 7.31 24 12 24z"
+	/>
+	<path
+		fill="#FBBC05"
+		d="M5.27 14.29c-.25-.72-.38-1.49-.38-2.29s.14-1.57.38-2.29V6.62H1.29A11.94 11.94 0 0 0 0 12c0 1.94.46 3.77 1.29 5.38l3.98-3.09z"
+	/>
+	<path
+		fill="#EA4335"
+		d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42C17.94 1.19 15.24 0 12 0 7.31 0 3.26 2.7 1.29 6.62l3.98 3.09C6.22 6.86 8.87 4.75 12 4.75z"
+	/>
+</svg>

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -8,8 +8,18 @@ import { env } from '$env/dynamic/private';
 if (!env.BETTER_AUTH_SECRET) throw new Error('BETTER_AUTH_SECRET is not set');
 if (!env.BETTER_AUTH_URL) throw new Error('BETTER_AUTH_URL is not set');
 
+// issue #42: Googleログイン。GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRETは他の必須環境変数と異なり
+// throwしない（Google Cloud Console側の発行はユーザーの別途対応であり、未発行の間もローカル開発・
+// CI・既存のemail/password認証を止めないため）。socialProviders.googleにundefinedを渡すと
+// Better Authランタイム（node_modules/better-auth/dist/context/create-context.mjs）が
+// `config == null` の分岐でプロバイダ自体を登録せずスキップすることを実ソースで確認済み。
+const googleClientId = env.GOOGLE_CLIENT_ID;
+const googleClientSecret = env.GOOGLE_CLIENT_SECRET;
+export const isGoogleAuthEnabled = Boolean(googleClientId && googleClientSecret);
+
 // issue #49: issue #3の自前実装（Cookie+DBセッション、argon2id）をBetter Authへ移行。
-// email/passwordのみを有効化し、OAuth・メール送信・プラグイン等は設定しない（#42/#44/#45のスコープ）。
+// email/passwordを有効化し、issue #42でGoogleソーシャルログインを追加した
+// （メール送信・その他プラグイン等は#44/#45のスコープ外のため設定しない）。
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: 'mysql'
@@ -19,6 +29,32 @@ export const auth = betterAuth({
 		minPasswordLength: 8,
 		maxPasswordLength: 255,
 		autoSignIn: true
+	},
+	// issue #42: Googleプロバイダ。未設定時はundefinedを渡し登録自体をスキップする（上記コメント参照）。
+	// スコープは追加設定しない（Better Authデフォルトのemail/profile/openidのみ。不変条件6）。
+	socialProviders: {
+		google: isGoogleAuthEnabled
+			? {
+					clientId: googleClientId as string,
+					clientSecret: googleClientSecret as string
+				}
+			: undefined
+	},
+	account: {
+		accountLinking: {
+			enabled: true,
+			// 「同一メールのGoogleログインは既存email/passwordユーザーへ自動リンクする」方針（spec.md 2-1(3)）。
+			// GoogleはtrustedProviderかつemail_verified:trueを返すため通常はこれで足りるが、
+			// Better Authランタイム（node_modules/.../@better-auth/core/src/types/init-options.ts、
+			// dist/oauth2/link-account.mjs）を確認したところ、`requireLocalEmailVerified`
+			// （既定true）が別途「既存ローカルユーザーのemailVerifiedがtrueであること」も要求しており、
+			// rootistの既存email/passwordユーザーはメール確認未実装（#45未着手）のためemailVerified
+			// は常にfalseで、既定のままでは自動リンクが常に "account not linked" で失敗する。
+			// spec.md 2-1(3)で明記された既知リスク（メール確認未実装ゆえのpre-account-takeover経路）
+			// を許容する前提のもと、自動リンクを実現するため明示的にfalseへ上書きする。
+			requireLocalEmailVerified: false,
+			trustedProviders: ['google']
+		}
 	},
 	session: {
 		// 既存の「30日・残り15日でスライド延長」に近い体験を維持する。

--- a/src/routes/auth/google/+page.server.ts
+++ b/src/routes/auth/google/+page.server.ts
@@ -1,0 +1,54 @@
+import { redirect } from '@sveltejs/kit';
+import { APIError } from 'better-auth';
+import type { Actions, PageServerLoad } from './$types';
+import { auth } from '$lib/server/auth';
+
+// issue #42: Googleログイン開始用の専用ルート。
+// SvelteKitは同一ページでdefaultアクションと名前付きアクションを混在できないため、
+// 既存の/login・/registerのdefaultアクションを一切変更せずに済むよう専用ルートを新設する
+// （spec.md 2-2）。GETアクセスは/logoutと同じPOST専用パターンで/loginへ303リダイレクトする。
+export const load: PageServerLoad = async () => {
+	redirect(303, '/login');
+};
+
+export const actions: Actions = {
+	default: async ({ request }) => {
+		// redirect()は例外を投げるため、実際に呼ぶのはtry/catchの外で行う
+		// （catch (err instanceof APIError) にredirectの内部例外を誤って捕捉させないため）。
+		let authorizationUrl: string | null = null;
+
+		try {
+			// auth.api.signInSocial は google プロバイダが未登録（環境変数未設定）の場合、
+			// APIError(NOT_FOUND, PROVIDER_NOT_FOUND) を投げる
+			// （node_modules/better-auth/dist/api/routes/sign-in.mjs で確認済み）。
+			// signInSocial自体はformCsrfMiddlewareを使わず、生成したstate/codeVerifierの
+			// CookieはsveltekitCookies(getRequestEvent)プラグインがevent.cookiesへ転送する。
+			const result = await auth.api.signInSocial({
+				body: {
+					provider: 'google',
+					callbackURL: '/plan',
+					errorCallbackURL: '/login'
+				},
+				headers: request.headers
+			});
+			authorizationUrl = result.url ?? null;
+		} catch (err) {
+			if (err instanceof APIError) {
+				// プロバイダ未登録（環境変数未設定）・その他Better Auth側のエラー。
+				// 500を露出させず/login?error=googleへ退避する（spec.md 2-2）。
+				console.error('auth/google action: signInSocial APIError', err.body?.code ?? err.message);
+				redirect(303, '/login?error=google');
+			}
+			throw err;
+		}
+
+		if (!authorizationUrl) {
+			// 理論上到達しない（disableRedirect未指定・idToken未指定のためurlは必ず返る）が、
+			// 万一urlが空の場合も500を露出させず/login?error=googleへ退避する。
+			console.error('auth/google action: signInSocial returned no url');
+			redirect(303, '/login?error=google');
+		}
+
+		redirect(303, authorizationUrl);
+	}
+};

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,14 +1,27 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { APIError } from 'better-auth';
 import type { Actions, PageServerLoad } from './$types';
-import { auth } from '$lib/server/auth';
+import { auth, isGoogleAuthEnabled } from '$lib/server/auth';
 import { normalizeEmail, LOGIN_FAILURE_MESSAGE } from '$lib/server/auth-errors';
 
+// issue #42: /auth/googleのerrorCallbackURLから戻ってきたエラーを画面表示用の
+// 固定日本語メッセージに変換する。生のエラーコード（?errorの値そのもの）は画面に出さない
+// （不変条件5、spec.md 2-3(3)）。
+const GOOGLE_LOGIN_FAILURE_MESSAGE =
+	'Googleログインを完了できませんでした。もう一度お試しください。';
+
 // ログイン済みユーザーが /login にアクセスしたら /plan へリダイレクトする
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
 	if (locals.user) {
 		redirect(303, '/plan');
 	}
+
+	const googleError = url.searchParams.has('error');
+
+	return {
+		googleAuthEnabled: isGoogleAuthEnabled,
+		googleError: googleError ? GOOGLE_LOGIN_FAILURE_MESSAGE : null
+	};
 };
 
 export const actions: Actions = {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,16 +3,22 @@
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Separator } from '$lib/components/ui/separator';
 	import * as Card from '$lib/components/ui/card';
 	import * as Field from '$lib/components/ui/field';
 	import * as Alert from '$lib/components/ui/alert';
 	import { AlertCircleIcon } from '@lucide/svelte';
-	import type { ActionData } from './$types';
+	import GoogleIcon from '$lib/components/google-icon.svelte';
+	import type { ActionData, PageData } from './$types';
 
-	let { form }: { form: ActionData } = $props();
+	let { form, data }: { form: ActionData; data: PageData } = $props();
 
 	let submitting = $state(false);
 	let password = $state('');
+
+	// issue #42: form?.message（email/passwordログイン失敗）とdata.googleError
+	// （Google側でのキャンセル・失敗）は排他表示でよい（spec.md 2-3(3)）
+	const errorMessage = $derived(form?.message ?? data.googleError ?? null);
 </script>
 
 <svelte:head>
@@ -40,10 +46,10 @@
 				}}
 				class="flex flex-col gap-4"
 			>
-				{#if form?.message}
+				{#if errorMessage}
 					<Alert.Root variant="destructive">
 						<AlertCircleIcon />
-						<Alert.Description>{form.message}</Alert.Description>
+						<Alert.Description>{errorMessage}</Alert.Description>
 					</Alert.Root>
 				{/if}
 
@@ -75,6 +81,20 @@
 					{submitting ? 'ログイン中…' : 'ログイン'}
 				</Button>
 			</form>
+
+			{#if data.googleAuthEnabled}
+				<div class="relative my-4 flex items-center justify-center">
+					<Separator class="absolute inset-x-0" />
+					<span class="relative bg-card px-2 text-xs text-muted-foreground">または</span>
+				</div>
+
+				<form method="POST" action="/auth/google">
+					<Button type="submit" variant="outline" class="w-full">
+						<GoogleIcon data-icon="inline-start" />
+						Googleでログイン
+					</Button>
+				</form>
+			{/if}
 		</Card.Content>
 		<Card.Footer class="justify-center text-sm text-muted-foreground">
 			アカウントをお持ちでない方は <a href={resolve('/register')} class="ml-1 text-accent underline"

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -1,7 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { APIError } from 'better-auth';
 import type { Actions, PageServerLoad } from './$types';
-import { auth } from '$lib/server/auth';
+import { auth, isGoogleAuthEnabled } from '$lib/server/auth';
 import {
 	normalizeEmail,
 	isValidEmailFormat,
@@ -15,6 +15,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
 		redirect(303, '/plan');
 	}
+
+	// issue #42: Rev.2契約で追加。/loginと同様、環境変数未設定時はボタン非表示にするための
+	// フラグをサーバーでのみ判定して渡す（環境変数の値自体はクライアントへ渡さない）。
+	return { googleAuthEnabled: isGoogleAuthEnabled };
 };
 
 export const actions: Actions = {

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -3,13 +3,15 @@
 	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Separator } from '$lib/components/ui/separator';
 	import * as Card from '$lib/components/ui/card';
 	import * as Field from '$lib/components/ui/field';
 	import * as Alert from '$lib/components/ui/alert';
 	import { AlertCircleIcon } from '@lucide/svelte';
-	import type { ActionData } from './$types';
+	import GoogleIcon from '$lib/components/google-icon.svelte';
+	import type { ActionData, PageData } from './$types';
 
-	let { form }: { form: ActionData } = $props();
+	let { form, data }: { form: ActionData; data: PageData } = $props();
 
 	let submitting = $state(false);
 	let password = $state('');
@@ -77,6 +79,20 @@
 					{submitting ? '登録中…' : '新規登録'}
 				</Button>
 			</form>
+
+			{#if data.googleAuthEnabled}
+				<div class="relative my-4 flex items-center justify-center">
+					<Separator class="absolute inset-x-0" />
+					<span class="relative bg-card px-2 text-xs text-muted-foreground">または</span>
+				</div>
+
+				<form method="POST" action="/auth/google">
+					<Button type="submit" variant="outline" class="w-full">
+						<GoogleIcon data-icon="inline-start" />
+						Googleで登録
+					</Button>
+				</form>
+			{/if}
 		</Card.Content>
 		<Card.Footer class="justify-center text-sm text-muted-foreground">
 			すでにアカウントをお持ちの方は <a href={resolve('/login')} class="ml-1 text-accent underline"


### PR DESCRIPTION
## なぜ

メール/パスワードでのユーザー登録・ログイン機能（issue #3）に続き、Googleアカウントでもログイン・新規登録できるようにしたいという要望があった。パスワードを新たに覚える必要が無く、登録の手間が減る。

close #42

（Appleアカウントログインは対象外。issue #56として別管理）

## 何を

- login / register 両ページに「Googleでログイン」ボタンを追加
- Googleアカウントでのログイン・新規登録、Better Auth標準の`account`テーブルとの連携
- OAuthでログインしたユーザーも、メール/パスワード登録ユーザーと同様にログイン状態が保持される
- Google Cloud Consoleでのクライアント登録が未実施のため、環境変数（`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`）未設定時はGoogleログイン機能自体を無効化し、ボタンを非表示にする（graceful degradation）

## どうやって

- Better Auth標準の`socialProviders.google`を`src/lib/server/auth.ts`に追加。コールバックは既存hooksの`svelteKitHandler`がそのまま処理するため追加実装不要
- ログイン開始専用に`src/routes/auth/google/+page.server.ts`を新設。SvelteKitはdefault actionと名前付きactionを混在できないため、既存login/registerのdefault actionには一切手を入れずに済む設計
- login/register双方の`+page.server.ts`のloadから`googleAuthEnabled`フラグを渡し、`+page.svelte`でボタン表示を切り替え。新規`google-icon.svelte`（`.claude/skills/shadcn-svelte`規約準拠、`data-icon="inline-start"`）
- `.github/workflows/ci.yml`にダミー環境変数を追加

### 実装中に発見した2つの技術的リスクとその対応

1. **`account.issuer`列の保護**: 現行の`account`テーブルには Better Auth標準フィールドに加え`issuer`列（NOT NULL、ユニークインデックス）が存在し、既存の email/password 認証が実際に依存している。`better-auth`のCLIでスキーマ差分を生成するとこの列が認識されず欠落した差分が出るが、ランタイム実ソース（`node_modules/better-auth`）を確認した結果、これはコアフィールドであり、CLI出力を鵜呑みにして反映すると**既存の全認証が停止する**リスクがあった。今回はスキーマ変更を行わず、この列を保護している。
2. **自動アカウントリンクの前提条件**: Better Authの`accountLinking`は既定で`requireLocalEmailVerified: true`（ローカルユーザーのメール確認済みを要求）だが、本プロジェクトはメール確認機能（issue #45）が未実装のため既存ユーザーの`emailVerified`は常に`false`。このままでは「同一メールアドレスでの自動アカウントリンク」が構造的に常に失敗するため、`auth.ts`でこの要求を明示的に緩和した（メール確認機能そのものには影響しない）。

### 開発フロー

product-spec-planner → spec-implementation-generator（Sprint Contract、QAレビュー1往復でRev.2に改訂）→ 実装 → strict-qa-evaluatorによる動的QA検証（Playwright実機）。

QAで確認済みの主な項目:
- 認可URL生成（`accounts.google.com`へのリダイレクト、スコープが`email profile openid`のみに限定、PKCE付き）
- 環境変数未設定時のgraceful degradation（ボタン非表示・500エラーにならず安全に失敗）と、その状態でも既存のメール/パスワード認証が正常動作すること
- エラー時の統一メッセージ表示、XSS風の不正な`error`クエリパラメータでもスクリプト注入されないこと
- 既存の登録・ログイン・ログアウト・共有ページ（`/plan/share/[shareId]`）・issue #54のアバター表示に非回帰がないこと
- `pnpm check` / `pnpm lint`（eslint単独実行含む）/ `pnpm test` が全て通過すること

### レビュアーへの補足・残タスク

**実際のGoogleアカウントでのログイン完走（新規ユーザー作成・既存ユーザーとの自動リンク・再ログイン時の非重複）は、Google Cloud ConsoleでのOAuthクライアント未登録のため未検証です。** 以下の対応が必要です。

- Google Cloud Consoleでプロジェクトを作成し、OAuth同意画面とクライアントID/シークレットを発行（リダイレクトURI: `<BETTER_AUTH_URL>/api/auth/callback/google`）
- 発行したクライアントID/シークレットを`.env`の`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`に設定
- 実際にGoogleアカウントでログインし、新規ユーザー作成・既存メール/パスワードユーザーとの自動リンク・`account`テーブルの`issuer`実値（想定: `https://accounts.google.com`）を手動確認

上記が完了するまで、issue #42はクローズしません（`.dev-loop/20260828-google-oauth-login/handoff.md`に運用を明記済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)