### PR TITLE
feat: Vitestのテストカバレッジ計測を導入する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test-results
+coverage
 node_modules
 .pnpm-store
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",
+		"test:coverage": "vitest run --coverage",
 		"test": "npm run test:unit -- --run && npm run test:e2e",
 		"test:e2e": "playwright test",
 		"db:start": "docker compose up",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
 	test: {
 		expect: { requireAssertions: true },
 
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'html'],
+			include: ['src/**/*.{ts,svelte}'],
+			exclude: [
+				'src/**/*.{test,spec}.{js,ts}',
+				'src/**/*.svelte.{test,spec}.{js,ts}',
+				'src/stories/**'
+			]
+		},
+
 		projects: [
 			{
 				extends: './vite.config.ts',


### PR DESCRIPTION
## なぜ

AIエージェントにコーディングを任せる開発フローにおいて、「テストが通っている」という自己申告だけでは、そのテストが実際にどこまでコードをカバーしているかが分からない。まずはカバレッジを計測・可視化できる状態を作りたい。

close #58

## 何を

- `vitest run --coverage` でテストカバレッジを計測できるようにする
- ファイル単位・行単位のカバー状況をターミナル出力＋HTMLレポートの両方で確認できるようにする
- 新規スクリプト `pnpm test:coverage` を追加（既存の `pnpm test:unit` 等は無変更）

## どうやって

- `@vitest/coverage-v8`（既にdevDependencyとして導入済み）を使い、`vite.config.ts` の `test` 設定に `coverage` ブロックを追加。プロバイダはV8ネイティブのカバレッジ機能（`provider: 'v8'`）を使用し、`client`/`server` 両プロジェクトに横断的に適用されるようトップレベルに配置した
- レポート形式は `text`（ターミナル即確認用）と `html`（`coverage/index.html`、行単位の詳細確認用）の両方を出力するようにした
- `src/stories/`（Storybookの初期セットアップ用サンプルコード、実アプリコードではない）はカバレッジ対象から除外した
- `coverage/` ディレクトリは生成物のため `.gitignore` に追加した

### 現状のカバレッジ

導入直後の実測値（`pnpm test:coverage`）: Statements 12.84% / Branches 4.21% / Functions 11.83% / Lines 9.65%。想定通り低い水準で、次のissueで段階的に引き上げていく。

### スコープ

このPRはカバレッジの計測・可視化のみが対象。カバレッジ率100%への引き上げ、QAエージェントの完了条件（DoD）への組み込みは別issueで対応する（issue #58の補足を参照）。

### 開発フロー

設定変更のみの軽微な変更のため、フルのエージェント開発フロー（spec/contract/QA往復）は使わず直接実装した。`pnpm check`（0 errors）・`pnpm exec eslint .`（0 errors）で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)