### PR TITLE
docs: コミットにCo-Authored-By記載を必須化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## git戦略
 
 - Conventional Commits
+- Claude Code（オーケストレーター本体・spec-implementation-generator等のサブエージェントを問わず）が作成するコミットには、コミット履歴の透明性を保つため必ず以下のトレーラーを含めること
+
+  ```
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
 
 ## Commands
 


### PR DESCRIPTION
## なぜ

Claude Codeが作成したコミットは、現状すべてユーザー本人のGitユーザー名義になっており、GitHub上では本人の単独コミットとして表示される。実際に直近の履歴を確認したところ、実装のほぼ全てがClaude Codeによるものにも関わらずCo-Authored-Byトレーラーが付いていないコミットが多数あった。コミット履歴の透明性を保つため、どのコミットがAIによって作成されたかを判別できるようにしたい。

close #60

## 何を

- Claude Codeが作成するコミットについて、AIが関与したことがコミット履歴から明確に分かるようにする

## どうやって

- CLAUDE.mdの「git戦略」セクションに、オーケストレーター本体だけでなくspec-implementation-generator等のサブエージェントを問わず、Claude Codeが作成するコミットには必ず`Co-Authored-By: Claude <noreply@anthropic.com>`トレーラーを含めることを明記した
- 抜け漏れの原因は、これまでのコミット指示がオーケストレーター向けの一般的な手順に留まり、このリポジトリ固有の運用ルールとして明文化されていなかったことにあると考えられる。CLAUDE.mdに明記することで、今後どのエージェントが作業してもこのルールを参照できるようにした
- ドキュメントのみの変更のため、フルのエージェント開発フローは使わず直接対応した

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>