### PR TITLE
feat: 「もう一度計画する」で作成画面の入力を復元する

### DIFF
--- a/src/lib/stores/route.ts
+++ b/src/lib/stores/route.ts
@@ -22,3 +22,22 @@ export interface RouteResult {
 }
 
 export const routeResult = writable<RouteResult | null>(null);
+
+/**
+ * 「もう一度計画する」で /plan に戻った際に入力欄へ復元する下書き（issue #64）。
+ * routeResult とは独立した型として持つ（生成結果ではなく「復元する入力」を表すため）。
+ * 保存は /plan/result の「もう一度計画する」ボタン押下時のみ、消費は /plan 初期化時の1回のみ。
+ */
+export interface PlanDraft {
+	origin: { name: string; displayAddress: string } | null;
+	transportMode: 'transit' | 'car' | 'walking' | '';
+	startTime: string;
+	endDestination: { name: string; displayAddress: string } | null;
+	locations: {
+		address: string;
+		displayAddress?: string;
+		timeSlot: 'morning' | 'noon' | 'night' | '';
+	}[];
+}
+
+export const planDraft = writable<PlanDraft | null>(null);

--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -31,20 +31,31 @@
 		AlertCircleIcon
 	} from '@lucide/svelte';
 	import { fly, slide, fade } from 'svelte/transition';
-	import { routeResult } from '$lib/stores/route';
+	import { get } from 'svelte/store';
+	import { routeResult, planDraft } from '$lib/stores/route';
+
+	// issue #64: 「もう一度計画する」で戻ってきた場合のみ、直前の入力を1回だけ復元する。
+	// 読み取り後は即座にリセットする消費型ストアのため、それ以外の経路（トップからの遷移・
+	// 共有ページ経由・直接URL・リロード等）では draft は常に null で「新規」扱いになる。
+	const restoredDraft = get(planDraft);
+	if (restoredDraft) planDraft.set(null);
 
 	// 移動手段
 	type TransportMode = 'transit' | 'car' | 'walking' | '';
-	let transportMode = $state<TransportMode>('');
+	let transportMode = $state<TransportMode>(restoredDraft?.transportMode ?? '');
 
 	// 出発地
-	let origin = $state<{ name: string; displayAddress: string } | null>(null);
+	let origin = $state<{ name: string; displayAddress: string } | null>(
+		restoredDraft?.origin ?? null
+	);
 
 	// 出発時刻
-	let startTime = $state('');
+	let startTime = $state(restoredDraft?.startTime ?? '');
 
 	// ゴール（宿泊先など）
-	let endDestination = $state<{ name: string; displayAddress: string } | null>(null);
+	let endDestination = $state<{ name: string; displayAddress: string } | null>(
+		restoredDraft?.endDestination ?? null
+	);
 	// ゴール入力欄の展開状態
 	let isGoalOpen = $state(false);
 
@@ -56,10 +67,17 @@
 		{ value: 'night', label: '晩', icon: Moon }
 	];
 
-	// 行きたい場所リスト
+	// 行きたい場所リスト（復元時はidを新規発行し直し、重複・欠落を防ぐ）
 	let locations = $state<
 		{ id: string; address: string; displayAddress?: string; timeSlot: TimeSlot }[]
-	>([]);
+	>(
+		(restoredDraft?.locations ?? []).map((loc) => ({
+			id: crypto.randomUUID(),
+			address: loc.address,
+			displayAddress: loc.displayAddress,
+			timeSlot: loc.timeSlot
+		}))
+	);
 	let isGenerating = $state(false);
 	let generateError = $state<string | null>(null);
 

--- a/src/routes/plan/page.svelte.test.ts
+++ b/src/routes/plan/page.svelte.test.ts
@@ -2,7 +2,7 @@ import { page } from 'vitest/browser';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { get } from 'svelte/store';
-import { routeResult } from '$lib/stores/route';
+import { routeResult, planDraft, type PlanDraft } from '$lib/stores/route';
 
 // issue #62: プラン作成ページのテスト。
 // /api/places（Google Places）と /api/route（Gemini）は課金対象なのでfetchをモックし実接続しない。
@@ -91,11 +91,13 @@ function toggleItem(groupLabel: string, itemLabel: string) {
 
 beforeEach(() => {
 	routeResult.set(null);
+	planDraft.set(null);
 	stubApis();
 });
 
 afterEach(() => {
 	routeResult.set(null);
+	planDraft.set(null);
 	vi.clearAllMocks();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
@@ -409,6 +411,113 @@ describe('/plan +page.svelte プラン作成', () => {
 
 		await expect
 			.element(page.getByText('通信エラーが発生しました。もう一度お試しください。'))
+			.toBeInTheDocument();
+	});
+});
+
+// issue #64: 「もう一度計画する」経由でのみ入力を復元する挙動のテスト。
+describe('/plan +page.svelte 入力の復元（もう一度計画する）', () => {
+	const DRAFT: PlanDraft = {
+		origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
+		transportMode: 'transit',
+		startTime: '09:30',
+		endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
+		locations: [
+			{ address: '浅草寺', displayAddress: '台東区浅草', timeSlot: 'morning' },
+			{ address: '東京タワー', displayAddress: '港区芝公園', timeSlot: '' }
+		]
+	};
+
+	it('draftがあれば出発地・出発時刻・移動手段・行きたい場所・ゴールを復元表示する', async () => {
+		planDraft.set(DRAFT);
+
+		const { container } = await renderPlan();
+
+		await expect.element(page.getByText('東京駅')).toBeInTheDocument();
+		await expect.element(page.getByText('千代田区丸の内')).toBeInTheDocument();
+		await expect.element(page.getByText('新宿グランドホテル')).toBeInTheDocument();
+		await expect.element(page.getByText('浅草寺')).toBeInTheDocument();
+		await expect.element(page.getByText('東京タワー')).toBeInTheDocument();
+		expect(container.textContent).toContain('2 箇所 · 作成できます');
+		expect(
+			(page.getByLabelText('時', { exact: true }).element() as HTMLElement).textContent?.trim()
+		).toBe('09');
+		expect(toggleItem('移動手段', '電車・公共交通')?.getAttribute('data-state')).toBe('on');
+		expect(toggleItem('訪問する時間帯', '朝')?.getAttribute('data-state')).toBe('on');
+	});
+
+	it('復元後、行きたい場所の追加・削除ができる', async () => {
+		planDraft.set(DRAFT);
+		const { container } = await renderPlan();
+
+		await addLocation('浅草寺');
+		await expect.element(page.getByText(/3 箇所/)).toBeInTheDocument();
+
+		const removeButtons = container.querySelectorAll('button:has(svg.lucide-trash-2)');
+		(removeButtons[0] as HTMLElement | undefined)?.click();
+
+		await vi.waitFor(() => expect(container.textContent).toContain('2 箇所'));
+	});
+
+	it('復元後にそのまま作成すると復元された内容で/api/routeを呼ぶ', async () => {
+		const fetchSpy = stubApis();
+		planDraft.set(DRAFT);
+		await renderPlan();
+
+		await generateButton().click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		const routeCall = fetchSpy.mock.calls.find(([url]) => String(url).includes('/api/route'));
+		const body = JSON.parse(routeCall![1].body);
+		expect(body.origin).toEqual(DRAFT.origin);
+		expect(body.transportMode).toBe('transit');
+		expect(body.startTime).toBe('09:30');
+		expect(body.endDestination).toEqual(DRAFT.endDestination);
+		expect(body.locations).toEqual([
+			{ name: '浅草寺', displayAddress: '台東区浅草', timeSlot: 'morning' },
+			{ name: '東京タワー', displayAddress: '港区芝公園', timeSlot: undefined }
+		]);
+	});
+
+	it('復元された行きたい場所には一意なidが振られる（キー重複・欠落なし）', async () => {
+		planDraft.set(DRAFT);
+		const { container } = await renderPlan();
+
+		// 行きたい場所リストの ItemGroup（class="gap-3"）配下に、件数分だけ item が重複・欠落なく描画される。
+		const items = container.querySelectorAll('[data-slot="item-group"].gap-3 [data-slot="item"]');
+		expect(items.length).toBe(DRAFT.locations.length);
+		expect([...items].map((el) => el.textContent)).toEqual([
+			expect.stringContaining('浅草寺'),
+			expect.stringContaining('東京タワー')
+		]);
+	});
+
+	it('draftは1回読み取ると消費され、ストアはnullに戻る', async () => {
+		planDraft.set(DRAFT);
+
+		await renderPlan();
+
+		expect(get(planDraft)).toBeNull();
+	});
+
+	it('draftを消費した後に再度render()しても2回目は空欄で始まる', async () => {
+		planDraft.set(DRAFT);
+		await renderPlan();
+		expect(get(planDraft)).toBeNull();
+
+		const { container } = await renderPlan();
+
+		expect(container.textContent).toContain('まだ行きたい場所がありません');
+		expect(container.textContent).toContain('0 箇所');
+	});
+
+	it('draftがnullのまま開始すると従来通り空欄で始まる（デグレ確認）', async () => {
+		const { container } = await renderPlan();
+
+		expect(container.textContent).toContain('まだ行きたい場所がありません');
+		expect(container.textContent).toContain('0 箇所');
+		await expect
+			.element(page.getByPlaceholder('例：自宅最寄り駅、宿泊ホテル...'))
 			.toBeInTheDocument();
 	});
 });

--- a/src/routes/plan/result/+page.svelte
+++ b/src/routes/plan/result/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { routeResult } from '$lib/stores/route';
+	import { routeResult, planDraft, type PlanDraft } from '$lib/stores/route';
 	import { Button } from '$lib/components/ui/button';
 	import PlanTimeline from '$lib/components/plan-timeline.svelte';
 	import { Navigation, RotateCcw, Share2, Check, Loader2 } from '@lucide/svelte';
@@ -34,6 +34,37 @@
 			// クリップボードAPIが使えない環境向けフォールバック: URLを手動コピーできるよう表示する
 			manualShareUrl = url;
 		}
+	}
+
+	const KNOWN_TRANSPORT_MODES = ['transit', 'car', 'walking'] as const;
+
+	/**
+	 * 現在の result から入力復元用の下書きを組み立てて planDraft にセットし、/plan へ戻る。
+	 * 「もう一度計画する」ボタン押下時のみ実行される（issue #64）。
+	 */
+	function planAgain() {
+		if (result) {
+			const transportMode = KNOWN_TRANSPORT_MODES.includes(
+				result.transportMode as (typeof KNOWN_TRANSPORT_MODES)[number]
+			)
+				? (result.transportMode as PlanDraft['transportMode'])
+				: '';
+			const draft: PlanDraft = {
+				origin: result.origin ?? null,
+				transportMode,
+				startTime: typeof result.startTime === 'string' ? result.startTime : '',
+				endDestination: result.endDestination ?? null,
+				locations: [...result.destinations]
+					.sort((a, b) => a.order - b.order)
+					.map((d) => ({
+						address: d.name,
+						displayAddress: d.displayAddress,
+						timeSlot: d.timeSlot ?? ''
+					}))
+			};
+			planDraft.set(draft);
+		}
+		goto(resolve('/plan'));
 	}
 
 	async function handleShare() {
@@ -112,7 +143,7 @@
 					</p>
 				{/if}
 				<Button
-					onclick={() => goto(resolve('/plan'))}
+					onclick={planAgain}
 					variant="outline"
 					class="w-full border-primary/20 text-primary hover:bg-primary/5"
 				>

--- a/src/routes/plan/result/page.svelte.test.ts
+++ b/src/routes/plan/result/page.svelte.test.ts
@@ -2,7 +2,7 @@ import { page } from 'vitest/browser';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { get } from 'svelte/store';
-import { routeResult, type RouteResult } from '$lib/stores/route';
+import { routeResult, planDraft, type RouteResult } from '$lib/stores/route';
 
 // issue #62: プラン結果ページのテスト。
 // /api/plans はDB書き込みを伴うためfetchをモックし、遷移とクリップボードもモックする。
@@ -62,11 +62,13 @@ function shareButton() {
 
 beforeEach(() => {
 	routeResult.set(RESULT);
+	planDraft.set(null);
 	stubClipboard(() => Promise.resolve());
 });
 
 afterEach(() => {
 	routeResult.set(null);
+	planDraft.set(null);
 	vi.clearAllMocks();
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
@@ -222,5 +224,83 @@ describe('/plan/result +page.svelte', () => {
 
 		expect(fetchSpy).toHaveBeenCalledOnce();
 		release?.();
+	});
+});
+
+// issue #64: 「もう一度計画する」押下時に routeResult から planDraft を組み立てる挙動のテスト。
+describe('/plan/result +page.svelte もう一度計画する（入力復元用のdraft組み立て）', () => {
+	const FULL_RESULT: RouteResult = {
+		summary: '浅草・東京タワーを巡る1日',
+		origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
+		transportMode: 'car',
+		startTime: '09:30',
+		endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
+		destinations: [
+			{
+				order: 2,
+				name: '東京タワー',
+				displayAddress: '港区芝公園',
+				arrivalTime: '11:00',
+				departureTime: '12:00',
+				description: '',
+				travelTimeFromPrevious: '30分',
+				timeSlot: null
+			},
+			{
+				order: 1,
+				name: '浅草寺',
+				displayAddress: '台東区浅草',
+				arrivalTime: '09:00',
+				departureTime: '10:30',
+				description: '雷門が有名',
+				travelTimeFromPrevious: null,
+				timeSlot: 'morning'
+			}
+		]
+	};
+
+	it('全項目を含むresultなら、order昇順に並べ替えたplanDraftをセットしてから/planへ遷移する', async () => {
+		routeResult.set(FULL_RESULT);
+		await renderResult();
+
+		await page.getByRole('button', { name: /もう一度計画する/ }).click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		expect(get(planDraft)).toEqual({
+			origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
+			transportMode: 'car',
+			startTime: '09:30',
+			endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
+			locations: [
+				{ address: '浅草寺', displayAddress: '台東区浅草', timeSlot: 'morning' },
+				{ address: '東京タワー', displayAddress: '港区芝公園', timeSlot: '' }
+			]
+		});
+	});
+
+	it('未指定項目を含むresultなら、該当フィールドはnullまたは空文字になる', async () => {
+		// RESULT フィクスチャは origin/transportMode/startTime/endDestination/timeSlot を持たない
+		await renderResult();
+
+		await page.getByRole('button', { name: /もう一度計画する/ }).click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		expect(get(planDraft)).toEqual({
+			origin: null,
+			transportMode: '',
+			startTime: '',
+			endDestination: null,
+			locations: [{ address: '浅草寺', displayAddress: '台東区浅草', timeSlot: '' }]
+		});
+	});
+
+	it('未知のtransportModeは空文字に丸める', async () => {
+		routeResult.set({ ...RESULT, transportMode: 'teleport' });
+		await renderResult();
+
+		await page.getByRole('button', { name: /もう一度計画する/ }).click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		expect(get(planDraft)?.transportMode).toBe('');
 	});
 });


### PR DESCRIPTION
## なぜ

生成されたプランを見て「行き先をもう1つ足したい」と思い「もう一度計画する」を押すと、作成画面の入力がすべて空になっていた。出発地・出発時刻・移動手段・既に入力済みの行き先まで一から入力し直しになり、ちょっとした調整をしたいだけの場面でやり直しの手間が大きすぎた。

close #64

## 何を

「もう一度計画する」で作成画面に戻ったとき、直前の入力内容（出発地・出発時刻・移動手段・行きたい場所とその時間帯指定・ゴール）を復元し、変更したい箇所だけ直して作り直せるようにした。

作成画面を新規に開いた場合（トップからの遷移・共有ページからの導線・直接URL・リロード・ブラウザの戻る）は、従来どおり空の状態から始まる。

## どうやって

- `src/lib/stores/route.ts` に `PlanDraft` 型と消費型ストア `planDraft` を追加した（既存の `routeResult` / `RouteResult` は無変更）
- `/plan/result` の「もう一度計画する」押下時**のみ**、`routeResult` から `planDraft` を組み立ててセットしてから遷移する
- `/plan` の初期化時に `planDraft` を一度だけ読み取って各 `$state` の初期値に反映し、即座に `null` へリセットする。この「ボタン経由でのみ積まれ、一度だけ消費される」という設計により、どの遷移を「新規」とみなすかの線引きが分岐なしで成立する
- 復元する `locations` の `id` は `crypto.randomUUID()` で再発行し、`{#each}` のキー重複・欠落を防いでいる

### SvelteKit公式の `snapshot` を使わなかった理由

ページ状態を保持する公式機能として `snapshot` があるが、`@sveltejs/kit` のランタイム実装を確認したところ、`capture` / `restore` は **popstate（ブラウザの戻る/進む）でのみ発火し、`goto()` による前方遷移では発火しない**。「もう一度計画する」は前方遷移のため要件に適合せず、採用を見送った。

localStorage / sessionStorage / URLクエリも比較検討したが、タブ間の独立性・リロード時に復元してほしくないという要件・実装量の観点からインメモリストアを選定した（詳細は `.dev-loop/20260829-plan-input-restore/spec.md`）。

## 検証

Playwright実機で以下を確認済み（Google Places / Gemini は課金対象のため `window.fetch` をスタブし、実APIは一切呼んでいない）。

- 復元後に行き先を**追加**してそのまま作り直せること（issueの元の動機）、削除・変更も同様
- 同じ場所を複数回追加してもキー重複やDOM崩れが起きないこと
- 出発地・時刻・移動手段・ゴールを未指定にした場合の丸め（空欄・ゴールカード非表示）が正しく復元されること
- 「新規に開いた場合は復元しない」が5通りの経路（リロード / トップから / 共有ページから / 直接URL / 戻るボタン）すべてで成立すること
- 一度復元した後は再度開いても復元されないこと（消費型ストア）
- プラン生成フロー・共有機能・`/login`・アバターメニューへの非回帰

品質ゲート: `pnpm lint`（exit 0）・`pnpm check`（0 errors）・`pnpm test`（unit 309件 + e2e 1件）すべて通過。テストカバレッジは Lines 100%（728/728）を維持し、Statements / Branches / Functions も微増した。

### 補足

本PRとは別に、リポジトリに残っていた古いgit worktree（`.claude/worktrees/chore-issue-template-dev-requirements`、マージ済みコミットを指したまま放置されていたもの）を削除した。これにより、これまで `pnpm lint` が prettier の警告3件で早期終了し eslint に到達していなかった問題が解消し、複合コマンドが額面通り通るようになっている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>