### PR TITLE
fix: 移動手段の「電車」を「公共交通機関」に改める

### DIFF
--- a/src/lib/components/plan-timeline.svelte
+++ b/src/lib/components/plan-timeline.svelte
@@ -34,7 +34,7 @@
 			{#if result.transportMode}
 				<p class="flex items-center gap-1 text-xs font-medium text-accent">
 					{#if result.transportMode === 'transit'}
-						<TrainFront class="size-3" /> 電車・公共交通
+						<TrainFront class="size-3" /> 公共交通機関
 					{:else if result.transportMode === 'car'}
 						<Car class="size-3" /> 車
 					{:else if result.transportMode === 'walking'}

--- a/src/lib/components/plan-timeline.svelte.test.ts
+++ b/src/lib/components/plan-timeline.svelte.test.ts
@@ -69,7 +69,7 @@ describe('plan-timeline', () => {
 	});
 
 	it.each([
-		['transit', '電車・公共交通'],
+		['transit', '公共交通機関'],
 		['car', '車'],
 		['walking', '徒歩']
 	])('移動手段 %s を日本語で表示する', async (mode, label) => {
@@ -81,14 +81,14 @@ describe('plan-timeline', () => {
 	it('未知の移動手段はどのラベルも表示しない', async () => {
 		const { container } = await renderTimeline(result({ transportMode: 'boat' }));
 
-		expect(container.textContent).not.toContain('電車・公共交通');
+		expect(container.textContent).not.toContain('公共交通機関');
 		expect(container.textContent).not.toContain('徒歩');
 	});
 
 	it('移動手段が未指定なら移動手段の行を表示しない', async () => {
 		const { container } = await renderTimeline(result({ transportMode: null }));
 
-		expect(container.textContent).not.toContain('電車・公共交通');
+		expect(container.textContent).not.toContain('公共交通機関');
 	});
 
 	it('出発地があれば「出発地」として表示する', async () => {

--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -229,11 +229,11 @@
 						>
 							<ToggleGroup.Item
 								value="transit"
-								aria-label="電車・公共交通"
+								aria-label="公共交通機関"
 								class="gap-1 px-2.5 text-xs data-[state=on]:border-accent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
 							>
 								<TrainFront />
-								電車
+								公共交通機関
 							</ToggleGroup.Item>
 							<ToggleGroup.Item
 								value="car"

--- a/src/routes/plan/page.svelte.test.ts
+++ b/src/routes/plan/page.svelte.test.ts
@@ -300,7 +300,7 @@ describe('/plan +page.svelte 任意条件の指定', () => {
 		await addLocation('東京タワー');
 		await addLocation('浅草寺');
 
-		toggleItem('移動手段', '電車・公共交通')?.click();
+		toggleItem('移動手段', '公共交通機関')?.click();
 		await generateButton().click();
 
 		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
@@ -521,7 +521,7 @@ describe('/plan +page.svelte 入力の復元（もう一度計画する）', () 
 		expect(
 			(page.getByLabelText('時', { exact: true }).element() as HTMLElement).textContent?.trim()
 		).toBe('09');
-		expect(toggleItem('移動手段', '電車・公共交通')?.getAttribute('data-state')).toBe('on');
+		expect(toggleItem('移動手段', '公共交通機関')?.getAttribute('data-state')).toBe('on');
 		expect(toggleItem('訪問する時間帯', '朝')?.getAttribute('data-state')).toBe('on');
 		expect(stayMinutesTrigger(0)?.textContent?.trim()).toBe('1時間30分');
 		expect(stayMinutesTrigger(1)?.textContent?.trim()).toBe('指定なし');


### PR DESCRIPTION
## なぜ

移動手段の選択肢が「電車」という表記だったが、この選択肢はバスなど鉄道以外の公共交通も含むもので、対象が実態より狭く伝わってしまっていた。

close #69

## 何を

作成画面の移動手段ボタンの表記を「電車」から「公共交通機関」に改めた。あわせて、そのボタンの `aria-label` と、結果画面・共有ページでの表示も同じ表記に揃えた。

## どうやって

- `src/routes/plan/+page.svelte` — ボタンの表示テキストと `aria-label` を「公共交通機関」に変更（可視テキストとアクセシブルネームを一致させる）
- `src/lib/components/plan-timeline.svelte` — 結果画面・共有ページの表示を「公共交通機関」に変更
- 上記を参照していたテストの期待値を更新

### Geminiへのプロンプトは変更していません

`src/routes/api/route/+server.ts` のプロンプト内は `電車・公共交通（駅・バス停ベースの移動と乗り換え待ち時間を考慮すること）` のままにしています。ここはユーザーに見えないモデルへの指示文で、具体性を落とさないほうが生成品質に有利と判断しました。表記を揃えたい場合は別途対応します。

## 検証

- 375px幅で「公共交通機関 / 車 / 徒歩」が1行に収まり、横スクロールが発生しないことを実機で確認（トグルグループ幅309px、ビューポート375pxに対して余裕あり）
- `pnpm lint`（exit 0）・`pnpm check`（0 errors）・`pnpm test`（unit 345件 + e2e 1件）すべて通過
- テストカバレッジは Lines 100%（770/770）を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>