### PR TITLE
fix: 時刻プルダウンがスクロールできない問題を修正

### DIFF
--- a/src/lib/components/time-picker.svelte.test.ts
+++ b/src/lib/components/time-picker.svelte.test.ts
@@ -1,5 +1,5 @@
 import { page } from 'vitest/browser';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import TimePicker from './time-picker.svelte';
 
@@ -87,6 +87,23 @@ describe('time-picker', () => {
 
 		await expect.element(page.getByRole('option', { name: '00' })).toBeInTheDocument();
 		await expect.element(page.getByRole('option', { name: '23' })).toBeInTheDocument();
+	});
+
+	// 24件ある時の一覧は画面高を超えるため、Select.Content に max-height（bits-ui が算出する
+	// 利用可能高）が無いとスクロールできず後半の時刻を選べなくなる。ブラウザテストには
+	// Tailwind のCSSが読み込まれず実際の高さは検証できないので、クラスの付与だけを守る。
+	it('時の一覧に画面内へ収める高さ制限クラスが付いている', async () => {
+		await render(TimePicker, {});
+
+		await page.getByLabelText('時').click();
+
+		const content = await vi.waitFor(() => {
+			const el = document.querySelector<HTMLElement>('[data-slot="select-content"]');
+			if (!el) throw new Error('select-content が開いていません');
+			return el;
+		});
+		expect(content.className).toContain('max-h-(--bits-select-content-available-height)');
+		expect(content.className).toContain('overflow-y-auto');
 	});
 
 	it('clearableでなければ「指定なし」の選択肢を出さない', async () => {

--- a/src/lib/components/ui/select/select-content.svelte
+++ b/src/lib/components/ui/select/select-content.svelte
@@ -27,7 +27,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			'relative isolate z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			'relative isolate z-50 max-h-(--bits-select-content-available-height) min-w-36 origin-(--bits-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 			className
 		)}
 		{...restProps}


### PR DESCRIPTION
## 🤔 なぜ（目的）

出発時刻・訪問時刻のプルダウンで、画面外にはみ出た時刻（画面高によっては17時以降）を選択できない状態だった。
共通のSelectコンポーネント側の問題で、issue #70 以前から存在していたが、行き先ごとの訪問時刻が
ページ下部に並ぶようになり顕在化した。

## 🎯 何を（変更の要約）

- `Select.Content` に高さ上限を与え、一覧が画面内に収まってスクロールできるようにした
- 高さ制限クラスの退行を防ぐテストを1件追加

## 🛠️ どうやって（実装アプローチ）

**原因は `max-height` の欠落**。`overflow-y-auto` は指定されていたが高さ上限が無いため、
要素が中身の高さ（時の一覧24件で680px）のまま伸びきり、スクロール領域そのものが発生していなかった。
ブラウザでの実測値:

| | 修正前 | 修正後 |
|---|---|---|
| `max-height` | `none` | `487px` |
| clientHeight / scrollHeight | 680 / 680（差が無くスクロール不可） | 487 / 680 |
| リスト下端 | 1007px（画面 814px、17〜23時が画面外） | 814px（画面内） |

**shadcn-svelte本来のクラスを補う形で修正した。** 独自の固定値（`max-h-60` 等）ではなく、
bits-uiがフローティング配置時に算出する `--bits-select-content-available-height` を使う。
トリガーの位置に応じて上下どちらに開いても、その場で使える高さに追従するため。
あわせて開閉アニメーションの基点となる `origin-(--bits-select-content-transform-origin)` も補った。

滞在時間（8件）は画面に収まるため影響が出ておらず、24件ある時の一覧でのみ再現していた。

**テストはクラスの付与を検証する形にした。** ブラウザテスト環境にはTailwindのCSSが読み込まれず
（計算値は `max-height: none`、項目高も未スタイルの17px）、実際の高さでは検証できないため。
検証方法の制約はテスト内のコメントに残してある。

## ⚠️ 影響範囲

`Select.Content` は滞在時間・時刻選択を含む全Selectで共有される。項目数が少なく画面に収まる
一覧の見た目は変わらない（上限に達しないため）。

## ✅ 検証

- [x] ブラウザで出発時刻・訪問時刻の両方を確認。ホイールスクロールと上下チェブロンで00〜23時すべてに到達できる
- [x] 上表のとおり `max-height` と要素高をDOMで実測
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` — パス
- [x] `pnpm test:unit --run` — 390 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

