### PR TITLE
feat: 旅行プランに日付を指定できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@eslint/compat": "^2.1.0",
 		"@eslint/js": "^9.39.5",
 		"@internationalized/date": "^3.12.3",
-		"@lucide/svelte": "^1.33.0",
+		"@lucide/svelte": "^1.38.0",
 		"@playwright/test": "^1.62.1",
 		"@storybook/addon-a11y": "^10.5.10",
 		"@storybook/addon-docs": "^10.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.12.3
         version: 3.12.3
       '@lucide/svelte':
-        specifier: ^1.33.0
-        version: 1.33.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))
+        specifier: ^1.38.0
+        version: 1.38.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -883,8 +883,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lucide/svelte@1.33.0':
-    resolution: {integrity: sha512-b+osTYG2V4dge5Lr7tnaTaahhy/4vH7Xb8zcqVjmctjwgkpXS0NNOJPkGzHHZoxtw/OO+2YAU28omeMfYCaawg==}
+  '@lucide/svelte@1.38.0':
+    resolution: {integrity: sha512-x7pHfNAqArsjCbxgMxWoGEM25AXY1vl7P9ooGvY/DxbzNGK6vrfsFFoSw4yyv1ajfHY2jGBgi7lbSExya15ABA==}
     peerDependencies:
       svelte: ^5
 
@@ -3711,7 +3711,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@1.33.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))':
+  '@lucide/svelte@1.38.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))':
     dependencies:
       svelte: 5.56.10(@typescript-eslint/types@8.67.0)
 

--- a/src/lib/components/date-picker.svelte
+++ b/src/lib/components/date-picker.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { parseDate, type DateValue } from '@internationalized/date';
+	import { Button } from '$lib/components/ui/button';
+	import * as Popover from '$lib/components/ui/popover';
+	import { Calendar } from '$lib/components/ui/calendar';
+	import { CalendarDays } from '@lucide/svelte';
+	import { cn } from '$lib/utils';
+	import { isPlanDate, formatPlanDate } from '$lib/plan-date';
+
+	// date-picker.svelte（issue #73）: プラン全体の日付を選ぶPopover + Calendar。
+	// 外部インターフェースは time-picker.svelte に揃える（value/id/onValueChange）。
+	// value/onValueChange は必ず "YYYY-MM-DD" 文字列に閉じ、Date型・CalendarDate型を境界に出さない。
+	let {
+		value = $bindable(''),
+		id,
+		onValueChange
+	}: {
+		value?: string;
+		id?: string;
+		onValueChange?: (value: string) => void;
+	} = $props();
+
+	let open = $state(false);
+
+	// Calendar内部表現（CalendarDate）への変換は境界内に閉じる。isPlanDateで検証済みの
+	// 値のみをparseDateに渡す（形式外の値をCalendarへ渡さないため）。
+	const selectedDate = $derived(isPlanDate(value) ? parseDate(value) : undefined);
+
+	// カレンダーの表示月（placeholder）はCalendar内部のロービングtabindex/矢印キー操作で
+	// 自由に書き換わる状態のため、selectedDateにreactiveに追従させ続けると
+	// （毎レンダリングで上書きしてしまい）キーボードでの月内移動を破壊する。
+	// Popoverを開いた瞬間にだけ現在値の月へ同期し、開いている間は内部の変更に任せる。
+	let placeholder = $state<DateValue | undefined>(undefined);
+	$effect(() => {
+		if (open) placeholder = selectedDate;
+	});
+
+	function handleSelect(date: DateValue | undefined) {
+		if (!date) return;
+		const next = date.toString();
+		value = next;
+		onValueChange?.(next);
+		open = false;
+	}
+
+	function clear() {
+		value = '';
+		onValueChange?.('');
+		open = false;
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				{id}
+				variant="outline"
+				aria-label="日付"
+				class={cn('w-full justify-start sm:w-56', !value && 'text-muted-foreground')}
+			>
+				<CalendarDays data-icon="inline-start" />
+				{isPlanDate(value) ? formatPlanDate(value) : '日付を指定'}
+			</Button>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="w-auto p-0">
+		<Calendar
+			type="single"
+			locale="ja-JP"
+			value={selectedDate}
+			onValueChange={handleSelect}
+			bind:placeholder
+		/>
+		{#if value}
+			<div class="border-t p-2">
+				<Button variant="ghost" size="sm" class="w-full" onclick={clear}>指定なしに戻す</Button>
+			</div>
+		{/if}
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/components/date-picker.svelte.test.ts
+++ b/src/lib/components/date-picker.svelte.test.ts
@@ -1,0 +1,187 @@
+import { page, userEvent } from 'vitest/browser';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import DatePicker from './date-picker.svelte';
+
+// issue #73: 日付ピッカーのテスト。値は "YYYY-MM-DD" 文字列、未選択は空文字。
+// 日セルの実セレクタは bits-ui のソース（calendar.svelte.js 486〜545行目）と実描画結果
+// （本テストの試し打ち）で確認済み: 各日セルは role="button" の <div> で data-bits-day="" を
+// 持ち、当月外セルにのみ data-outside-month="" が付く。デフォルトのCalendar.Dayはchildren/child
+// snippetを渡さないため、テキストは日番号のみ（例: "12"）。
+
+/** カレンダー内の「当月の」日セル要素のうち、テキストが String(n) と一致するものを返す。 */
+function dayCell(n: number): HTMLElement | undefined {
+	const cells = Array.from(document.querySelectorAll<HTMLElement>('[data-bits-day]'));
+	return cells
+		.filter((c) => !c.hasAttribute('data-outside-month'))
+		.find((c) => c.textContent?.trim() === String(n));
+}
+
+function trigger() {
+	return page.getByLabelText('日付');
+}
+
+/** Popoverの閉じるアニメーション（duration-100）後にcontentがDOMから外れるのを待つ。 */
+async function waitForPopoverClosed() {
+	await vi.waitFor(() => {
+		if (document.querySelector('[data-slot="popover-content"]')) {
+			throw new Error('popover-content がまだ存在する');
+		}
+	});
+}
+
+describe('date-picker', () => {
+	it('未選択時、トリガーのテキストは「日付を指定」', async () => {
+		await render(DatePicker, {});
+
+		await expect.element(trigger()).toHaveTextContent('日付を指定');
+	});
+
+	it('valueを渡すと、トリガーのテキストが「YYYY年M月D日（曜）」になる', async () => {
+		await render(DatePicker, { value: '2026-09-05' });
+
+		await expect.element(trigger()).toHaveTextContent('2026年9月5日（土）');
+	});
+
+	it('トリガーを押すと2026年9月のカレンダーが開き、12日を選ぶとonValueChangeが呼ばれ表示が更新され閉じる', async () => {
+		const changes: string[] = [];
+		await render(DatePicker, { value: '2026-09-05', onValueChange: (v) => changes.push(v) });
+
+		await trigger().click();
+		const cell = dayCell(12);
+		expect(cell).toBeTruthy();
+		cell?.click();
+
+		expect(changes).toEqual(['2026-09-12']);
+		await expect.element(trigger()).toHaveTextContent('2026年9月12日（土）');
+		await waitForPopoverClosed();
+	});
+
+	it('値があるときのみ「指定なしに戻す」が表示され、押すと未指定に戻る', async () => {
+		const changes: string[] = [];
+		await render(DatePicker, { value: '2026-09-05', onValueChange: (v) => changes.push(v) });
+
+		await trigger().click();
+		await expect.element(page.getByRole('button', { name: '指定なしに戻す' })).toBeInTheDocument();
+
+		await page.getByRole('button', { name: '指定なしに戻す' }).click();
+
+		expect(changes).toEqual(['']);
+		await expect.element(trigger()).toHaveTextContent('日付を指定');
+		await waitForPopoverClosed();
+	});
+
+	it('選択済みの日を再度クリックしても（bits-uiの選択解除）onValueChangeを呼ばず値も変えない', async () => {
+		// preventDeselectを設定していないため、選択済み日を再クリックするとbits-uiは
+		// 内部的に選択解除しonValueChangeをundefinedで呼ぶ。「指定なしに戻す」以外の経路で
+		// 未指定に戻さないという設計（spec 2-3）を守るため、date-picker側でこれを無視する。
+		const changes: string[] = [];
+		await render(DatePicker, { value: '2026-09-05', onValueChange: (v) => changes.push(v) });
+
+		await trigger().click();
+		const selected = dayCell(5);
+		selected?.click();
+
+		expect(changes).toEqual([]);
+		await expect.element(trigger()).toHaveTextContent('2026年9月5日（土）');
+	});
+
+	it('値が無いときは「指定なしに戻す」ボタンが表示されない', async () => {
+		await render(DatePicker, {});
+
+		await trigger().click();
+
+		await expect
+			.element(page.getByRole('button', { name: '指定なしに戻す' }))
+			.not.toBeInTheDocument();
+
+		// 次のテストへ影響を残さないようPopoverを閉じてから終える
+		await userEvent.keyboard('{Escape}');
+		await waitForPopoverClosed();
+	});
+
+	describe('キーボード操作', () => {
+		it('Tabでトリガーにフォーカスが移り、Enterでカレンダーが開く', async () => {
+			await render(DatePicker, { value: '2026-09-05' });
+
+			await userEvent.tab();
+			await expect.element(trigger()).toHaveFocus();
+
+			await userEvent.keyboard('{Enter}');
+
+			await expect
+				.element(page.elementLocator(document.querySelector('[data-slot="popover-content"]')!))
+				.toBeInTheDocument();
+
+			// 次のテストへ影響を残さないようPopoverを閉じてから終える
+			await userEvent.keyboard('{Escape}');
+			await waitForPopoverClosed();
+		});
+
+		it('開いた状態でArrowRight押下によりフォーカス中の日セルが翌日へ移動し、Enterで確定してPopoverが閉じる', async () => {
+			const changes: string[] = [];
+			await render(DatePicker, { value: '2026-09-05', onValueChange: (v) => changes.push(v) });
+
+			await trigger().click();
+			// Popoverが開いた直後、bits-uiのfocus-scopeが非同期(rAF)でDOM順の最初のtabbable
+			// 要素（前月ボタン）へオートフォーカスする。このオートフォーカスが確定する前に
+			// 日セルへフォーカスすると、後から発火するオートフォーカスに上書きされ得るため、
+			// まずオートフォーカスがPopover内の要素に定まるのを待ってから、ロービングtabindexで
+			// tabindex=0が付く選択済み日セルへ改めてフォーカスする。
+			await vi.waitFor(() => {
+				const content = document.querySelector('[data-slot="popover-content"]');
+				if (!content || !content.contains(document.activeElement)) {
+					throw new Error('オートフォーカスが確定していない');
+				}
+			});
+			// rAFで予約されたオートフォーカスの再発火が収まるのを待ってから、改めて日セルへフォーカスする
+			await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+			const startCell = dayCell(5);
+			expect(startCell?.getAttribute('tabindex')).toBe('0');
+			startCell?.focus();
+			await vi.waitFor(() => {
+				expect(document.activeElement?.textContent?.trim()).toBe('5');
+			});
+			await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+			expect(document.activeElement?.textContent?.trim()).toBe('5');
+
+			await userEvent.keyboard('{ArrowRight}');
+			await vi.waitFor(() => {
+				expect(document.activeElement?.textContent?.trim()).toBe('6');
+			});
+
+			await userEvent.keyboard('{Enter}');
+
+			expect(changes).toEqual(['2026-09-06']);
+			await expect.element(trigger()).toHaveTextContent('2026年9月6日（日）');
+			await waitForPopoverClosed();
+		});
+
+		it('Escapeを押すとonValueChangeを呼ばずに値を変えないままPopoverが閉じ、フォーカスがトリガーへ戻る', async () => {
+			const changes: string[] = [];
+			await render(DatePicker, { value: '2026-09-05', onValueChange: (v) => changes.push(v) });
+
+			await trigger().click();
+			await userEvent.keyboard('{Escape}');
+
+			expect(changes).toEqual([]);
+			await expect.element(trigger()).toHaveTextContent('2026年9月5日（土）');
+			await waitForPopoverClosed();
+			await expect.element(trigger()).toHaveFocus();
+		});
+
+		it('「指定なしに戻す」ボタンがTabで到達可能で、アクセシブルネームで取得できる', async () => {
+			await render(DatePicker, { value: '2026-09-05' });
+
+			await trigger().click();
+
+			await expect
+				.element(page.getByRole('button', { name: '指定なしに戻す' }))
+				.toBeInTheDocument();
+
+			// 次のテストへ影響を残さないようPopoverを閉じてから終える
+			await userEvent.keyboard('{Escape}');
+			await waitForPopoverClosed();
+		});
+	});
+});

--- a/src/lib/components/plan-timeline.svelte
+++ b/src/lib/components/plan-timeline.svelte
@@ -9,12 +9,14 @@
 		TrainFront,
 		Car,
 		Footprints,
-		Flag
+		Flag,
+		CalendarDays
 	} from '@lucide/svelte';
 	import { fly } from 'svelte/transition';
 	import type { RouteResult } from '$lib/stores/route';
 	import { isStayMinutesPreset, formatStayMinutes } from '$lib/stay-minutes';
 	import { isVisitTime } from '$lib/visit-time';
+	import { isPlanDate, formatPlanDate } from '$lib/plan-date';
 
 	interface Props {
 		result: RouteResult;
@@ -32,6 +34,12 @@
 <div in:fly={{ y: 10, duration: 500, delay: 100 }}>
 	<Card.Root class="border-accent/20 bg-accent/10">
 		<Card.Content class="flex flex-col gap-2">
+			{#if isPlanDate(result.planDate)}
+				<div class="flex items-center gap-1 text-sm font-bold text-primary">
+					<CalendarDays class="size-4" />
+					<p>{formatPlanDate(result.planDate)}</p>
+				</div>
+			{/if}
 			{#if result.transportMode}
 				<p class="flex items-center gap-1 text-xs font-medium text-accent">
 					{#if result.transportMode === 'transit'}

--- a/src/lib/components/plan-timeline.svelte.test.ts
+++ b/src/lib/components/plan-timeline.svelte.test.ts
@@ -273,6 +273,28 @@ describe('plan-timeline', () => {
 		await expect.element(page.getByText('滞在1時間指定')).toBeInTheDocument();
 	});
 
+	it('planDateがあれば曜日付きで表示する', async () => {
+		await renderTimeline(result({ planDate: '2026-09-05' }));
+
+		await expect.element(page.getByText('2026年9月5日（土）')).toBeInTheDocument();
+	});
+
+	it('planDateが無ければ日付を表示しない', async () => {
+		const { container } = await renderTimeline(result());
+
+		expect(container.textContent).not.toMatch(/\d{4}年\d{1,2}月\d{1,2}日/);
+	});
+
+	it.each([null, '', '2026-02-30', '2026/09/05'])(
+		'planDateが不正な値 %s なら日付を表示しない',
+		async (planDate) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const { container } = await renderTimeline(result({ planDate: planDate as any }));
+
+			expect(container.textContent).not.toMatch(/\d{4}年\d{1,2}月\d{1,2}日/);
+		}
+	);
+
 	it('目的地が空でも描画できる', async () => {
 		const { container } = await renderTimeline(result({ destinations: [], summary: '目的地なし' }));
 

--- a/src/lib/components/ui/calendar/calendar-caption.svelte
+++ b/src/lib/components/ui/calendar/calendar-caption.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { DateFormatter, getLocalTimeZone, type DateValue } from '@internationalized/date';
+	import CalendarMonthSelect from './calendar-month-select.svelte';
+	import CalendarYearSelect from './calendar-year-select.svelte';
+	import type Calendar from './calendar.svelte';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		captionLayout,
+		months,
+		monthFormat,
+		years,
+		yearFormat,
+		month,
+		locale,
+		placeholder = $bindable(),
+		monthIndex = 0
+	}: {
+		captionLayout: ComponentProps<typeof Calendar>['captionLayout'];
+		months: ComponentProps<typeof CalendarMonthSelect>['months'];
+		monthFormat: ComponentProps<typeof CalendarMonthSelect>['monthFormat'];
+		years: ComponentProps<typeof CalendarYearSelect>['years'];
+		yearFormat: ComponentProps<typeof CalendarYearSelect>['yearFormat'];
+		month: DateValue;
+		placeholder: DateValue | undefined;
+		locale: string;
+		monthIndex: number;
+	} = $props();
+
+	function formatYear(date: DateValue) {
+		const dateObj = date.toDate(getLocalTimeZone());
+		if (typeof yearFormat === 'function') return yearFormat(dateObj.getFullYear());
+		return new DateFormatter(locale, { year: yearFormat }).format(dateObj);
+	}
+
+	function formatMonth(date: DateValue) {
+		const dateObj = date.toDate(getLocalTimeZone());
+		if (typeof monthFormat === 'function') return monthFormat(dateObj.getMonth() + 1);
+		return new DateFormatter(locale, { month: monthFormat }).format(dateObj);
+	}
+</script>
+
+{#snippet MonthSelect()}
+	<CalendarMonthSelect
+		{months}
+		{monthFormat}
+		value={month.month}
+		onchange={(e) => {
+			if (!placeholder) return;
+			const v = Number.parseInt(e.currentTarget.value);
+			const newPlaceholder = placeholder.set({ month: v });
+			placeholder = newPlaceholder.subtract({ months: monthIndex });
+		}}
+	/>
+{/snippet}
+
+{#snippet YearSelect()}
+	<CalendarYearSelect {years} {yearFormat} value={month.year} />
+{/snippet}
+
+{#if captionLayout === 'dropdown'}
+	{@render MonthSelect()}
+	{@render YearSelect()}
+{:else if captionLayout === 'dropdown-months'}
+	{@render MonthSelect()}
+	{#if placeholder}
+		{formatYear(placeholder)}
+	{/if}
+{:else if captionLayout === 'dropdown-years'}
+	{#if placeholder}
+		{formatMonth(placeholder)}
+	{/if}
+	{@render YearSelect()}
+{:else}
+	{formatMonth(month)} {formatYear(month)}
+{/if}

--- a/src/lib/components/ui/calendar/calendar-cell.svelte
+++ b/src/lib/components/ui/calendar/calendar-cell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.CellProps = $props();
+</script>
+
+<CalendarPrimitive.Cell
+	bind:ref
+	class={cn(
+		'relative size-(--cell-size) p-0 text-center text-sm focus-within:z-20 [&:first-child[data-selected]_[data-bits-day]]:rounded-s-(--cell-radius) [&:last-child[data-selected]_[data-bits-day]]:rounded-e-(--cell-radius)',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-day.svelte
+++ b/src/lib/components/ui/calendar/calendar-day.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.DayProps = $props();
+</script>
+
+<CalendarPrimitive.Day
+	bind:ref
+	class={cn(
+		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none',
+		'[&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
+		'not-data-selected:hover:bg-accent/50 not-data-selected:hover:text-accent-foreground',
+		'[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground [&[data-today][data-disabled]]:text-muted-foreground',
+		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:text-foreground',
+		// Outside months
+		'[&[data-outside-month]:not([data-selected])]:text-muted-foreground [&[data-outside-month]:not([data-selected])]:hover:text-accent-foreground',
+		// Disabled
+		'data-[disabled]:pointer-events-none data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
+		// Unavailable
+		'data-[unavailable]:text-muted-foreground data-[unavailable]:line-through',
+		// focus
+		'focus:relative focus:border-ring focus:ring-ring/50',
+		// inner spans
+		'[&>span]:text-xs [&>span]:opacity-70',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-grid-body.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-body.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.GridBodyProps = $props();
+</script>
+
+<CalendarPrimitive.GridBody bind:ref class={cn(className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid-head.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-head.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.GridHeadProps = $props();
+</script>
+
+<CalendarPrimitive.GridHead bind:ref class={cn(className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid-row.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid-row.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.GridRowProps = $props();
+</script>
+
+<CalendarPrimitive.GridRow bind:ref class={cn('flex', className)} {...restProps} />

--- a/src/lib/components/ui/calendar/calendar-grid.svelte
+++ b/src/lib/components/ui/calendar/calendar-grid.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.GridProps = $props();
+</script>
+
+<CalendarPrimitive.Grid
+	bind:ref
+	class={cn('flex w-full border-collapse flex-col', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-head-cell.svelte
+++ b/src/lib/components/ui/calendar/calendar-head-cell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.HeadCellProps = $props();
+</script>
+
+<CalendarPrimitive.HeadCell
+	bind:ref
+	class={cn(
+		'w-(--cell-size) rounded-md text-[0.8rem] font-normal text-muted-foreground',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-header.svelte
+++ b/src/lib/components/ui/calendar/calendar-header.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.HeaderProps = $props();
+</script>
+
+<CalendarPrimitive.Header
+	bind:ref
+	class={cn(
+		'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-heading.svelte
+++ b/src/lib/components/ui/calendar/calendar-heading.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CalendarPrimitive.HeadingProps = $props();
+</script>
+
+<CalendarPrimitive.Heading
+	bind:ref
+	class={cn('px-(--cell-size) text-sm font-medium', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/calendar/calendar-month-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-month-select.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value,
+		onchange,
+		...restProps
+	}: WithoutChildrenOrChild<CalendarPrimitive.MonthSelectProps> = $props();
+</script>
+
+<span
+	class={cn(
+		'relative flex rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
+		className
+	)}
+>
+	<CalendarPrimitive.MonthSelect
+		bind:ref
+		class="absolute inset-0 bg-background opacity-0 dark:bg-popover dark:text-popover-foreground"
+		{...restProps}
+	>
+		{#snippet child({ props, monthItems, selectedMonthItem })}
+			<select {...props} {value} {onchange}>
+				{#each monthItems as monthItem (monthItem.value)}
+					<option
+						value={monthItem.value}
+						selected={value !== undefined
+							? monthItem.value === value
+							: monthItem.value === selectedMonthItem.value}
+					>
+						{monthItem.label}
+					</option>
+				{/each}
+			</select>
+			<span
+				class="flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5 [&>svg]:text-muted-foreground"
+				aria-hidden="true"
+			>
+				{monthItems.find((item) => item.value === value)?.label || selectedMonthItem.label}
+				<ChevronDownIcon class={cn('size-4', className)} />
+			</span>
+		{/snippet}
+	</CalendarPrimitive.MonthSelect>
+</span>

--- a/src/lib/components/ui/calendar/calendar-month.svelte
+++ b/src/lib/components/ui/calendar/calendar-month.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { type WithElementRef, cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div {...restProps} bind:this={ref} class={cn('flex w-full flex-col gap-4', className)}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/calendar/calendar-months.svelte
+++ b/src/lib/components/ui/calendar/calendar-months.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn('relative flex flex-col gap-4 md:flex-row', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/calendar/calendar-nav.svelte
+++ b/src/lib/components/ui/calendar/calendar-nav.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<nav
+	{...restProps}
+	bind:this={ref}
+	class={cn('absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1', className)}
+>
+	{@render children?.()}
+</nav>

--- a/src/lib/components/ui/calendar/calendar-next-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-next-button.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import { buttonVariants, type ButtonVariant } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		variant = 'ghost',
+		...restProps
+	}: CalendarPrimitive.NextButtonProps & {
+		variant?: ButtonVariant;
+	} = $props();
+</script>
+
+{#snippet Fallback()}
+	<ChevronRightIcon class={cn('size-4', className)} />
+{/snippet}
+
+<CalendarPrimitive.NextButton
+	bind:ref
+	class={cn(
+		buttonVariants({ variant }),
+		'size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180',
+		className
+	)}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		{@render Fallback()}
+	{/if}
+</CalendarPrimitive.NextButton>

--- a/src/lib/components/ui/calendar/calendar-prev-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-prev-button.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
+	import { buttonVariants, type ButtonVariant } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		variant = 'ghost',
+		...restProps
+	}: CalendarPrimitive.PrevButtonProps & {
+		variant?: ButtonVariant;
+	} = $props();
+</script>
+
+{#snippet Fallback()}
+	<ChevronLeftIcon class={cn('size-4', className)} />
+{/snippet}
+
+<CalendarPrimitive.PrevButton
+	bind:ref
+	class={cn(
+		buttonVariants({ variant }),
+		'size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180',
+		className
+	)}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		{@render Fallback()}
+	{/if}
+</CalendarPrimitive.PrevButton>

--- a/src/lib/components/ui/calendar/calendar-year-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-year-select.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value,
+		...restProps
+	}: WithoutChildrenOrChild<CalendarPrimitive.YearSelectProps> = $props();
+</script>
+
+<span
+	class={cn(
+		'relative flex rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
+		className
+	)}
+>
+	<CalendarPrimitive.YearSelect
+		bind:ref
+		class="absolute inset-0 opacity-0 dark:bg-popover dark:text-popover-foreground"
+		{...restProps}
+	>
+		{#snippet child({ props, yearItems, selectedYearItem })}
+			<select {...props} {value}>
+				{#each yearItems as yearItem (yearItem.value)}
+					<option
+						value={yearItem.value}
+						selected={value !== undefined
+							? yearItem.value === value
+							: yearItem.value === selectedYearItem.value}
+					>
+						{yearItem.label}
+					</option>
+				{/each}
+			</select>
+			<span
+				class="flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5 [&>svg]:text-muted-foreground"
+				aria-hidden="true"
+			>
+				{yearItems.find((item) => item.value === value)?.label || selectedYearItem.label}
+				<ChevronDownIcon class={cn('size-4', className)} />
+			</span>
+		{/snippet}
+	</CalendarPrimitive.YearSelect>
+</span>

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { isEqualMonth, type DateValue } from '@internationalized/date';
+	import { Calendar as CalendarPrimitive } from 'bits-ui';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import * as Calendar from './index.js';
+	import type { ButtonVariant } from '../button/button.svelte';
+	import type { Snippet } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		placeholder = $bindable(),
+		class: className,
+		weekdayFormat = 'short',
+		buttonVariant = 'ghost',
+		captionLayout = 'label',
+		locale = 'en-US',
+		months: monthsProp,
+		years,
+		monthFormat: monthFormatProp,
+		yearFormat = 'numeric',
+		day,
+		disableDaysOutsideMonth = false,
+		...restProps
+	}: WithoutChildrenOrChild<CalendarPrimitive.RootProps> & {
+		buttonVariant?: ButtonVariant;
+		captionLayout?: 'dropdown' | 'dropdown-months' | 'dropdown-years' | 'label';
+		months?: CalendarPrimitive.MonthSelectProps['months'];
+		years?: CalendarPrimitive.YearSelectProps['years'];
+		monthFormat?: CalendarPrimitive.MonthSelectProps['monthFormat'];
+		yearFormat?: CalendarPrimitive.YearSelectProps['yearFormat'];
+		day?: Snippet<[{ day: DateValue; outsideMonth: boolean }]>;
+	} = $props();
+
+	const monthFormat = $derived.by(() => {
+		if (monthFormatProp) return monthFormatProp;
+		if (captionLayout.startsWith('dropdown')) return 'short';
+		return 'long';
+	});
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<CalendarPrimitive.Root
+	bind:value={value as never}
+	bind:ref
+	bind:placeholder
+	{weekdayFormat}
+	{disableDaysOutsideMonth}
+	class={cn(
+		'group/calendar bg-background p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+		className
+	)}
+	{locale}
+	{monthFormat}
+	{yearFormat}
+	{...restProps}
+>
+	{#snippet children({ months, weekdays })}
+		<Calendar.Months>
+			<Calendar.Nav>
+				<Calendar.PrevButton variant={buttonVariant} />
+				<Calendar.NextButton variant={buttonVariant} />
+			</Calendar.Nav>
+			{#each months as month, monthIndex (month)}
+				<Calendar.Month>
+					<Calendar.Header>
+						<Calendar.Caption
+							{captionLayout}
+							months={monthsProp}
+							{monthFormat}
+							{years}
+							{yearFormat}
+							month={month.value}
+							bind:placeholder
+							{locale}
+							{monthIndex}
+						/>
+					</Calendar.Header>
+					<Calendar.Grid>
+						<Calendar.GridHead>
+							<Calendar.GridRow class="select-none">
+								{#each weekdays as weekday, i (i)}
+									<Calendar.HeadCell>
+										{weekday.slice(0, 2)}
+									</Calendar.HeadCell>
+								{/each}
+							</Calendar.GridRow>
+						</Calendar.GridHead>
+						<Calendar.GridBody>
+							{#each month.weeks as weekDates (weekDates)}
+								<Calendar.GridRow class="mt-2 w-full">
+									{#each weekDates as date (date)}
+										<Calendar.Cell {date} month={month.value}>
+											{#if day}
+												{@render day({
+													day: date,
+													outsideMonth: !isEqualMonth(date, month.value)
+												})}
+											{:else}
+												<Calendar.Day />
+											{/if}
+										</Calendar.Cell>
+									{/each}
+								</Calendar.GridRow>
+							{/each}
+						</Calendar.GridBody>
+					</Calendar.Grid>
+				</Calendar.Month>
+			{/each}
+		</Calendar.Months>
+	{/snippet}
+</CalendarPrimitive.Root>

--- a/src/lib/components/ui/calendar/index.ts
+++ b/src/lib/components/ui/calendar/index.ts
@@ -1,0 +1,40 @@
+import Caption from './calendar-caption.svelte';
+import Cell from './calendar-cell.svelte';
+import Day from './calendar-day.svelte';
+import GridBody from './calendar-grid-body.svelte';
+import GridHead from './calendar-grid-head.svelte';
+import GridRow from './calendar-grid-row.svelte';
+import Grid from './calendar-grid.svelte';
+import HeadCell from './calendar-head-cell.svelte';
+import Header from './calendar-header.svelte';
+import Heading from './calendar-heading.svelte';
+import MonthSelect from './calendar-month-select.svelte';
+import Month from './calendar-month.svelte';
+import Months from './calendar-months.svelte';
+import Nav from './calendar-nav.svelte';
+import NextButton from './calendar-next-button.svelte';
+import PrevButton from './calendar-prev-button.svelte';
+import YearSelect from './calendar-year-select.svelte';
+import Root from './calendar.svelte';
+
+export {
+	Day,
+	Cell,
+	Grid,
+	Header,
+	Months,
+	GridRow,
+	Heading,
+	GridBody,
+	GridHead,
+	HeadCell,
+	NextButton,
+	PrevButton,
+	Nav,
+	Month,
+	YearSelect,
+	MonthSelect,
+	Caption,
+	//
+	Root as Calendar
+};

--- a/src/lib/plan-date.test.ts
+++ b/src/lib/plan-date.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { isPlanDate, formatPlanDate } from './plan-date';
+
+// issue #73: planDate（プラン全体の日付）の形式検証・実在日判定・表示整形の単体テスト。
+
+describe('isPlanDate', () => {
+	it.each(['2026-09-05', '2026-01-01', '2024-02-29', '1999-12-31', '2099-12-31'])(
+		'%s は true',
+		(value) => {
+			expect(isPlanDate(value)).toBe(true);
+		}
+	);
+
+	it.each([
+		'2026-9-5',
+		'2026-02-30',
+		'2026-13-01',
+		'2026-04-31',
+		'2026/09/05',
+		'2026-09-05T00:00:00Z',
+		'',
+		'abc',
+		20260905,
+		null,
+		undefined,
+		{}
+	])('%s は false', (value) => {
+		expect(isPlanDate(value)).toBe(false);
+	});
+});
+
+describe('formatPlanDate', () => {
+	it.each([
+		['2026-09-05', '2026年9月5日（土）'],
+		['2026-01-01', '2026年1月1日（木）'],
+		['2026-12-31', '2026年12月31日（木）'],
+		['2024-02-29', '2024年2月29日（木）']
+	])('%s → %s', (input, expected) => {
+		expect(formatPlanDate(input)).toBe(expected);
+	});
+
+	it('月日がゼロ埋めされない', () => {
+		expect(formatPlanDate('2026-01-01')).not.toContain('01月');
+		expect(formatPlanDate('2026-01-01')).not.toContain('01日');
+	});
+
+	it('isPlanDateを満たさない形式外の入力は空文字を返す（防御的フォールバック）', () => {
+		expect(formatPlanDate('2026/09/05')).toBe('');
+	});
+
+	describe('タイムゾーン非依存', () => {
+		const ORIGINAL_TZ = process.env.TZ;
+
+		afterEach(() => {
+			process.env.TZ = ORIGINAL_TZ;
+		});
+
+		it.each(['UTC', 'Asia/Tokyo', 'Pacific/Midway', 'Pacific/Kiritimati'])(
+			'TZ=%s でも 2026年9月5日（土） になる',
+			(tz) => {
+				process.env.TZ = tz;
+				expect(formatPlanDate('2026-09-05')).toBe('2026年9月5日（土）');
+			}
+		);
+	});
+});

--- a/src/lib/plan-date.ts
+++ b/src/lib/plan-date.ts
@@ -1,0 +1,63 @@
+/**
+ * 旅行プラン全体の日付（"YYYY-MM-DD"）に関する共有ロジック（issue #73）。
+ *
+ * `date-picker.svelte` の入力・`/api/route` のホワイトリスト検証とエコーバック・
+ * `/api/plans` の保存・`plan-timeline.svelte` の表示の4箇所で同じ形式判定と
+ * 表示整形を使い回すための共通モジュール。
+ *
+ * タイムゾーン方針: `planDate` はタイムゾーンを持たないカレンダー日付として扱う。
+ * 実行環境のタイムゾーンに影響されるローカル時刻系の読み出しAPIは一切使わず、
+ * `Date.UTC` で構築し `getUTC` 系のメソッドでのみ読み出す。サーバー側で
+ * 「現在時刻」を起点に既定値を補完する処理もここには置かない。
+ * import は一切行わない（純関数のみ）。
+ */
+
+/** "YYYY-MM-DD"（ゼロ埋め必須）の形式のみを許容する。 */
+const PLAN_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** 曜日（UTCの getUTCDay() の返り値 0=日〜6=土 に対応）。 */
+const WEEKDAY_KANJI = ['日', '月', '火', '水', '木', '金', '土'] as const;
+
+/**
+ * "YYYY-MM-DD" 形式かつ実在するカレンダー日付かどうかを判定する。
+ * stayMinutes のプリセット判定・visitTime の形式判定と同じく
+ * 「ホワイトリスト外・形式外はプロンプト汚染・不正表示防止のため無視する」方針に使う。
+ */
+export function isPlanDate(value: unknown): value is string {
+	if (typeof value !== 'string') return false;
+	const match = PLAN_DATE_PATTERN.exec(value);
+	if (!match) return false;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+
+	const utcMs = Date.UTC(year, month - 1, day);
+	const rebuilt = new Date(Date.UTC(year, month - 1, day));
+
+	// Date.UTC は月・日のオーバーフローを吸収して繰り上げてしまうため、
+	// 構築後の年・月・日（UTC）が入力と一致するかで実在日を確認する。
+	return (
+		Number.isFinite(utcMs) &&
+		rebuilt.getUTCFullYear() === year &&
+		rebuilt.getUTCMonth() === month - 1 &&
+		rebuilt.getUTCDate() === day
+	);
+}
+
+/**
+ * "2026-09-05" → "2026年9月5日（土）" に変換する。
+ * 呼び出し前に必ず `isPlanDate` でガードすること（本関数は形式チェックをしない）。
+ */
+export function formatPlanDate(date: string): string {
+	const match = PLAN_DATE_PATTERN.exec(date);
+	if (!match) return '';
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+
+	const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+
+	return `${year}年${month}月${day}日（${WEEKDAY_KANJI[dow]}）`;
+}

--- a/src/lib/stores/route.ts
+++ b/src/lib/stores/route.ts
@@ -20,6 +20,8 @@ export interface RouteResult {
 	transportMode?: string | null;
 	startTime?: string | null;
 	endDestination?: { name: string; displayAddress: string } | null;
+	/** プラン全体の日付 "YYYY-MM-DD"（未指定・既存データはnull/キー欠落）。issue #73 */
+	planDate?: string | null;
 	destinations: RouteDestination[];
 	summary: string;
 }
@@ -36,6 +38,8 @@ export interface PlanDraft {
 	transportMode: 'transit' | 'car' | 'walking' | '';
 	startTime: string;
 	endDestination: { name: string; displayAddress: string } | null;
+	/** プラン全体の日付 "YYYY-MM-DD"（未指定は空文字）。issue #73 */
+	planDate: string;
 	locations: {
 		address: string;
 		displayAddress?: string;

--- a/src/routes/api/plans/+server.ts
+++ b/src/routes/api/plans/+server.ts
@@ -4,6 +4,7 @@ import { db } from '$lib/server/db';
 import { plans } from '$lib/server/db/schema';
 import type { RequestHandler } from './$types';
 import type { RouteDestination, RouteResult } from '$lib/stores/route';
+import { isPlanDate } from '$lib/plan-date';
 
 // 保存時に受け入れる既知フィールドのみを対象とする（任意の巨大キー混入防止）
 const DESTINATION_KEYS = [
@@ -104,6 +105,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		origin: pickPlace(rec.origin),
 		transportMode: typeof rec.transportMode === 'string' ? rec.transportMode : null,
 		startTime: typeof rec.startTime === 'string' ? rec.startTime : null,
+		planDate: isPlanDate(rec.planDate) ? rec.planDate : null,
 		endDestination: pickPlace(rec.endDestination) ?? null
 	};
 

--- a/src/routes/api/plans/server.test.ts
+++ b/src/routes/api/plans/server.test.ts
@@ -221,6 +221,28 @@ describe('POST /api/plans 保存', () => {
 		expect(saved.startTime).toBeNull();
 	});
 
+	it('planDateを含むボディをPOSTすると保存されたdata.planDateがその値になる', async () => {
+		await POST(jsonEvent({ destinations: [destination(1)], planDate: '2026-09-05' }));
+
+		expect(insertValues.mock.calls[0][0].data.planDate).toBe('2026-09-05');
+	});
+
+	it('planDate未指定なら保存data.planDateはnull', async () => {
+		await POST(jsonEvent({ destinations: [destination(1)] }));
+
+		expect(insertValues.mock.calls[0][0].data.planDate).toBeNull();
+	});
+
+	it.each(['2026-02-30', '2026/09/05', 123, {}])(
+		'不正なplanDate %s は保存data.planDateをnullにし、保存自体は成功する（201）',
+		async (planDate) => {
+			const res = await POST(jsonEvent({ destinations: [destination(1)], planDate }));
+
+			expect(res.status).toBe(201);
+			expect(insertValues.mock.calls[0][0].data.planDate).toBeNull();
+		}
+	);
+
 	it('DB insertが失敗したら500を投げ、DBの生エラーは返さない', async () => {
 		vi.spyOn(console, 'error').mockImplementation(() => {});
 		insertValues.mockRejectedValue(new Error('ER_DUP_ENTRY: secret table detail'));

--- a/src/routes/api/route/+server.ts
+++ b/src/routes/api/route/+server.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 import { isStayMinutesPreset, formatStayMinutes } from '$lib/stay-minutes';
 import { isVisitTime, parseTimeToMinutes } from '$lib/visit-time';
+import { isPlanDate } from '$lib/plan-date';
 
 type TimeSlot = 'morning' | 'noon' | 'night';
 
@@ -28,18 +29,23 @@ export const POST: RequestHandler = async ({ request }) => {
 		origin,
 		transportMode,
 		startTime,
-		endDestination
+		endDestination,
+		planDate
 	}: {
 		locations: Location[];
 		origin?: Location;
 		transportMode?: string;
 		startTime?: string;
 		endDestination?: Location;
+		planDate?: string;
 	} = await request.json();
 
 	if (!locations || locations.length < 2) {
 		error(400, '2件以上の目的地が必要です');
 	}
+
+	// プラン全体の日付: 形式外・実在しない日はホワイトリスト外として無視する（プロンプトには一切注入しない）
+	const validPlanDate = isPlanDate(planDate) ? planDate : undefined;
 
 	// 時間帯: whitelist（4値）以外は undefined として無視（プロンプト汚染防止）
 	const validSlots = new Set<TimeSlot>(['morning', 'noon', 'night']);
@@ -265,6 +271,7 @@ ${locationList}
 		origin,
 		transportMode: transportMode ?? null,
 		startTime: startTime ?? null,
-		endDestination: endDestination ?? null
+		endDestination: endDestination ?? null,
+		planDate: validPlanDate ?? null
 	});
 };

--- a/src/routes/api/route/server.test.ts
+++ b/src/routes/api/route/server.test.ts
@@ -43,7 +43,10 @@ function stubGemini(payload: unknown = { destinations: [], summary: '概要' }, 
 	vi.stubGlobal('fetch', fetchSpy);
 	return {
 		fetchSpy,
-		prompt: () => JSON.parse(fetchSpy.mock.calls[0][1].body).contents[0].parts[0].text as string
+		prompt: () => JSON.parse(fetchSpy.mock.calls[0][1].body).contents[0].parts[0].text as string,
+		// issue #73 §5.2方式B: プロンプト文字列だけでなくGeminiへの送信ボディ全文（生文字列、非パース）を取得する。
+		// systemInstruction等の第3経路を含め、planDateの有無でボディが1バイトも変わらないことを機械的に担保する。
+		requestBody: () => fetchSpy.mock.calls[0][1].body as string
 	};
 }
 
@@ -387,6 +390,89 @@ describe('POST /api/route プロンプト組み立て', () => {
 	});
 });
 
+describe('POST /api/route planDate（issue #73）', () => {
+	// 不変条件1（本issueの核）: planDate は Gemini のプロンプトに一切注入しない。
+	it('プロンプト文字列にplanDateの値・整形結果・「日付」という語のいずれも含めない', async () => {
+		const { prompt } = stubGemini();
+
+		await POST(eventWith({ locations: TWO_LOCATIONS, planDate: '2026-09-05' }));
+
+		expect(prompt()).not.toContain('2026-09-05');
+		expect(prompt()).not.toContain('2026年9月5日');
+		expect(prompt()).not.toContain('日付');
+	});
+
+	// 非回帰（§5.2方式B・N-6反映）: planDateの有無でリクエストボディが1バイトも変わらないことを、
+	// 最小構成・全部盛り構成の2形状で確認する（条件付き注入 if(origin && planDate) 等の取り逃しを防ぐ）。
+	it.each([
+		['最小構成', {}],
+		[
+			'全部盛り構成',
+			{
+				origin: { name: '東京駅', displayAddress: '千代田区' },
+				endDestination: { name: 'ホテル', displayAddress: '新宿区' },
+				transportMode: 'transit',
+				startTime: '09:00'
+			}
+		]
+	])('%s: planDateの有無でリクエストボディが完全一致する', async (_label, extra) => {
+		const withoutDate = stubGemini();
+		await POST(
+			eventWith({
+				locations: [
+					{ ...TWO_LOCATIONS[0], timeSlot: 'morning', stayMinutes: 60, arriveAt: '10:00' },
+					TWO_LOCATIONS[1]
+				],
+				...extra
+			})
+		);
+		const bodyWithoutDate = withoutDate.requestBody();
+
+		const withDate = stubGemini();
+		await POST(
+			eventWith({
+				locations: [
+					{ ...TWO_LOCATIONS[0], timeSlot: 'morning', stayMinutes: 60, arriveAt: '10:00' },
+					TWO_LOCATIONS[1]
+				],
+				...extra,
+				planDate: '2026-09-05'
+			})
+		);
+		const bodyWithDate = withDate.requestBody();
+
+		expect(bodyWithDate).toBe(bodyWithoutDate);
+	});
+
+	it('有効なplanDateを渡すとレスポンスにそのまま返す', async () => {
+		stubGemini();
+
+		const res = await POST(eventWith({ locations: TWO_LOCATIONS, planDate: '2026-09-05' }));
+
+		expect((await res.json()).planDate).toBe('2026-09-05');
+	});
+
+	it('planDate未指定ならレスポンスのplanDateはnull', async () => {
+		stubGemini();
+
+		const res = await POST(eventWith({ locations: TWO_LOCATIONS }));
+
+		expect((await res.json()).planDate).toBeNull();
+	});
+
+	it.each(['2026-02-30', '2026-9-5', '2026/09/05', '', 20260905, null, {}])(
+		'不正なplanDate %s はレスポンスでnullになり200相当のレスポンスが返る（400にしない）',
+		async (planDate) => {
+			stubGemini();
+
+			const res = await POST(eventWith({ locations: TWO_LOCATIONS, planDate }));
+
+			expect(res.status).toBe(200);
+			expect((await res.json()).planDate).toBeNull();
+		}
+	);
+});
+
 describe('POST /api/route レスポンス整形', () => {
 	it('Geminiの生成結果に入力条件を添えて返す', async () => {
 		stubGemini({ destinations: [], summary: '概要' });
@@ -407,7 +493,8 @@ describe('POST /api/route レスポンス整形', () => {
 			origin: { name: '東京駅', displayAddress: '千代田区' },
 			transportMode: 'transit',
 			startTime: '09:00',
-			endDestination: { name: 'ホテル', displayAddress: '新宿区' }
+			endDestination: { name: 'ホテル', displayAddress: '新宿区' },
+			planDate: null
 		});
 	});
 

--- a/src/routes/plan/+page.svelte
+++ b/src/routes/plan/+page.svelte
@@ -13,6 +13,7 @@
 	import * as Select from '$lib/components/ui/select';
 	import PlaceCombobox from '$lib/components/place-combobox.svelte';
 	import TimePicker from '$lib/components/time-picker.svelte';
+	import DatePicker from '$lib/components/date-picker.svelte';
 	import {
 		MapPin,
 		Navigation,
@@ -53,6 +54,9 @@
 
 	// 出発時刻
 	let startTime = $state(restoredDraft?.startTime ?? '');
+
+	// プラン全体の日付（"YYYY-MM-DD"、未指定は空文字）
+	let planDate = $state(restoredDraft?.planDate ?? '');
 
 	// ゴール（宿泊先など）
 	let endDestination = $state<{ name: string; displayAddress: string } | null>(
@@ -130,6 +134,7 @@
 					origin: origin ?? undefined,
 					transportMode: transportMode || undefined,
 					startTime: startTime || undefined,
+					planDate: planDate || undefined,
 					endDestination: endDestination ?? undefined,
 					locations: locations.map((l) => ({
 						name: l.address,
@@ -181,6 +186,20 @@
 				</p>
 			</div>
 		</header>
+
+		<!-- 日付カード（任意） -->
+		<Card.Root class="gap-3 border-primary/10 bg-card/50 py-4 shadow-none">
+			<Card.Content class="flex flex-col gap-3 px-4">
+				<div>
+					<p class="text-sm font-bold text-primary">日付（任意）</p>
+					<p class="text-xs text-muted-foreground">指定すると結果画面と共有ページに表示されます</p>
+				</div>
+				<Field.Field>
+					<Field.FieldLabel for="planDate" class="sr-only">日付</Field.FieldLabel>
+					<DatePicker id="planDate" bind:value={planDate} />
+				</Field.Field>
+			</Card.Content>
+		</Card.Root>
 
 		<!-- 出発カード（任意） -->
 		<Card.Root class="gap-3 border-primary/10 bg-card/50 py-4 shadow-none">

--- a/src/routes/plan/page.svelte.test.ts
+++ b/src/routes/plan/page.svelte.test.ts
@@ -115,6 +115,28 @@ function arriveAtTrigger(index = 0) {
 	return document.querySelectorAll('[aria-label="訪問時刻の時"]')[index] as HTMLElement | undefined;
 }
 
+/** 日付ピッカーのトリガー要素を取得する（issue #73）。 */
+function planDateTrigger() {
+	return document.querySelector('[aria-label="日付"]') as HTMLElement | undefined;
+}
+
+/**
+ * 日付ピッカーを開き、当月のn日をクリックする（issue #73）。
+ * 日セルは bits-ui の実装依存の role="button" div（data-bits-day属性）で見分ける
+ * （date-picker.svelte.test.ts の dayCell ヘルパーと同じ考え方）。
+ */
+async function pickPlanDay(n: number) {
+	await page.getByLabelText('日付').click();
+	const cell = await vi.waitFor(() => {
+		const found = [...document.querySelectorAll<HTMLElement>('[data-bits-day]')]
+			.filter((c) => !c.hasAttribute('data-outside-month'))
+			.find((c) => c.textContent?.trim() === String(n));
+		if (!found) throw new Error(`日セル${n}が見つかりません`);
+		return found;
+	});
+	cell.click();
+}
+
 beforeEach(() => {
 	routeResult.set(null);
 	planDraft.set(null);
@@ -170,6 +192,13 @@ describe('/plan +page.svelte 初期表示', () => {
 			.toBeInTheDocument();
 		await expect.element(page.getByLabelText('移動手段')).toBeInTheDocument();
 		await expect.element(page.getByText('出発時刻')).toBeInTheDocument();
+	});
+
+	it('「日付（任意）」の見出しと、テキストが「日付を指定」のトリガーを表示する', async () => {
+		await renderPlan();
+
+		await expect.element(page.getByText('日付（任意）')).toBeInTheDocument();
+		expect(planDateTrigger()?.textContent?.trim()).toBe('日付を指定');
 	});
 
 	it('ゴールは折りたたんだ状態で始まる', async () => {
@@ -520,6 +549,74 @@ describe('/plan +page.svelte 任意条件の指定', () => {
 			displayAddress: '台東区浅草'
 		});
 	});
+
+	it('日付を指定して作成すると/api/routeのリクエストボディにplanDateが含まれる', async () => {
+		// 「今日」に依存しないため実行日によらず安定させる: planDraftで固定日付から復元した状態で
+		// 12日をクリックし、送信ボディが復元月内の別の日付になることを検証する。
+		const fetchSpy = stubApis();
+		planDraft.set({
+			origin: null,
+			transportMode: '',
+			startTime: '',
+			planDate: '2026-09-05',
+			endDestination: null,
+			locations: [
+				{
+					address: '東京タワー',
+					displayAddress: '港区芝公園',
+					timeSlot: '',
+					stayMinutes: '',
+					arriveAt: ''
+				},
+				{
+					address: '浅草寺',
+					displayAddress: '台東区浅草',
+					timeSlot: '',
+					stayMinutes: '',
+					arriveAt: ''
+				}
+			]
+		});
+		await renderPlan();
+
+		await pickPlanDay(12);
+		await generateButton().click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		const routeCall = fetchSpy.mock.calls.find(([url]) => String(url).includes('/api/route'));
+		expect(JSON.parse(routeCall![1].body).planDate).toBe('2026-09-12');
+	});
+
+	it('日付を指定せずに作成すると、送信ボディにplanDateが含まれない', async () => {
+		const fetchSpy = stubApis();
+		await renderPlan();
+		await addLocation('東京タワー');
+		await addLocation('浅草寺');
+
+		await generateButton().click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		const routeCall = fetchSpy.mock.calls.find(([url]) => String(url).includes('/api/route'));
+		expect(JSON.parse(routeCall![1].body).planDate).toBeUndefined();
+	});
+
+	it('日付を指定してから「指定なしに戻す」で解除して作成すると、送信ボディのplanDateがundefinedになる', async () => {
+		const fetchSpy = stubApis();
+		await renderPlan();
+		await addLocation('東京タワー');
+		await addLocation('浅草寺');
+
+		await pickPlanDay(12);
+		expect(planDateTrigger()?.textContent?.trim()).not.toBe('日付を指定');
+		await page.getByLabelText('日付').click();
+		await page.getByRole('button', { name: '指定なしに戻す' }).click();
+
+		await generateButton().click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		const routeCall = fetchSpy.mock.calls.find(([url]) => String(url).includes('/api/route'));
+		expect(JSON.parse(routeCall![1].body).planDate).toBeUndefined();
+	});
 });
 
 describe('/plan +page.svelte プラン作成', () => {
@@ -604,6 +701,7 @@ describe('/plan +page.svelte 入力の復元（もう一度計画する）', () 
 		origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
 		transportMode: 'transit',
 		startTime: '09:30',
+		planDate: '2026-09-05',
 		endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
 		locations: [
 			{
@@ -643,6 +741,15 @@ describe('/plan +page.svelte 入力の復元（もう一度計画する）', () 
 		expect(stayMinutesTrigger(1)?.textContent?.trim()).toBe('指定なし');
 		expect(arriveAtTrigger(0)?.textContent?.trim()).toBe('--');
 		expect(arriveAtTrigger(1)?.textContent?.trim()).toBe('13');
+		expect(planDateTrigger()?.textContent?.trim()).toBe('2026年9月5日（土）');
+	});
+
+	it('planDateが空文字のdraftでは復元後のトリガー表示が「日付を指定」のまま', async () => {
+		planDraft.set({ ...DRAFT, planDate: '' });
+
+		await renderPlan();
+
+		expect(planDateTrigger()?.textContent?.trim()).toBe('日付を指定');
 	});
 
 	it('復元後、行きたい場所の追加・削除ができる', async () => {
@@ -671,6 +778,7 @@ describe('/plan +page.svelte 入力の復元（もう一度計画する）', () 
 		expect(body.origin).toEqual(DRAFT.origin);
 		expect(body.transportMode).toBe('transit');
 		expect(body.startTime).toBe('09:30');
+		expect(body.planDate).toBe('2026-09-05');
 		expect(body.endDestination).toEqual(DRAFT.endDestination);
 		expect(body.locations).toEqual([
 			{

--- a/src/routes/plan/result/+page.svelte
+++ b/src/routes/plan/result/+page.svelte
@@ -53,6 +53,7 @@
 				origin: result.origin ?? null,
 				transportMode,
 				startTime: typeof result.startTime === 'string' ? result.startTime : '',
+				planDate: typeof result.planDate === 'string' ? result.planDate : '',
 				endDestination: result.endDestination ?? null,
 				locations: [...result.destinations]
 					.sort((a, b) => a.order - b.order)

--- a/src/routes/plan/result/page.svelte.test.ts
+++ b/src/routes/plan/result/page.svelte.test.ts
@@ -234,6 +234,7 @@ describe('/plan/result +page.svelte もう一度計画する（入力復元用�
 		origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
 		transportMode: 'car',
 		startTime: '09:30',
+		planDate: '2026-09-05',
 		endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
 		destinations: [
 			{
@@ -274,6 +275,7 @@ describe('/plan/result +page.svelte もう一度計画する（入力復元用�
 			origin: { name: '東京駅', displayAddress: '千代田区丸の内' },
 			transportMode: 'car',
 			startTime: '09:30',
+			planDate: '2026-09-05',
 			endDestination: { name: '新宿グランドホテル', displayAddress: '新宿区西新宿' },
 			locations: [
 				{
@@ -305,6 +307,7 @@ describe('/plan/result +page.svelte もう一度計画する（入力復元用�
 			origin: null,
 			transportMode: '',
 			startTime: '',
+			planDate: '',
 			endDestination: null,
 			locations: [
 				{
@@ -316,6 +319,19 @@ describe('/plan/result +page.svelte もう一度計画する（入力復元用�
 				}
 			]
 		});
+	});
+
+	it.each([
+		['null', null],
+		['undefined（キー欠落）', undefined]
+	])('planDateが%sならplanDraft.planDateは空文字になる', async (_label, planDate) => {
+		routeResult.set({ ...RESULT, planDate });
+		await renderResult();
+
+		await page.getByRole('button', { name: /もう一度計画する/ }).click();
+
+		await vi.waitFor(() => expect(goto).toHaveBeenCalled());
+		expect(get(planDraft)?.planDate).toBe('');
 	});
 
 	it('未知のtransportModeは空文字に丸める', async () => {

--- a/src/routes/plan/share/[shareId]/page.svelte.test.ts
+++ b/src/routes/plan/share/[shareId]/page.svelte.test.ts
@@ -59,6 +59,16 @@ describe('/plan/share/[shareId] +page.svelte', () => {
 			.toBeInTheDocument();
 	});
 
+	it('planDateを持つプランでは共有ページにも同じ日付文字列を表示する', async () => {
+		await render(SharePage, {
+			data: { user: null, result: { ...RESULT, planDate: '2026-09-05' } },
+			params: { shareId: 'abc' },
+			form: null
+		});
+
+		await expect.element(page.getByText('2026年9月5日（土）')).toBeInTheDocument();
+	});
+
 	it('目的地が空のプランでも描画できる', async () => {
 		const { container } = await render(SharePage, {
 			data: { user: null, result: { summary: '目的地なし', destinations: [] } },


### PR DESCRIPTION
## 🤔 なぜ（目的）

共有URLを受け取った同行者は、時刻だけを見ても何月何日の行程なのか判別できず、日付を別途連絡で伝える必要があった。作った本人も、複数のプランを見返すとどれがいつのプランなのか区別できなかった。旅行プランを名乗る以上あって当然の情報が欠けていた。

Closes #73

## 🎯 何を（変更の要約）

- プラン全体に任意の日付（`planDate`）を指定できるようになった
- 結果画面・共有ページの概要カード最上部に、曜日付き（例: `2026年9月5日（土）`）で表示される
- 未指定なら従来どおり日付表示は出ない
- 「もう一度計画する」で戻ったとき、指定した日付が復元される
- 既存の保存済み共有プラン（`planDate`キーを持たないデータ）は非破壊（日付行が出ないだけで、他は従来どおり表示される）

**スコープ外**（issueで明示済み）: 日付をGeminiのプロンプトに入れて生成に反映すること（曜日・定休日・営業時間の考慮）。これは別途Notionのロードマップに要望として記録済み。

## 🛠️ どうやって（実装アプローチ）

**issue #66（滞在時間）・#70（訪問時刻）と同じ統合パターンに揃えた**: 共有モジュールでの検証 → 入力UI → `planDraft`復元 → `/api/route`でのユーザー入力の権威付きエコーバック → `plan-timeline.svelte`での表示 → `/api/plans`での保存、という一直線の流れ。

**`src/lib/plan-date.ts`（新規）** に `isPlanDate`（`"YYYY-MM-DD"`形式＋実在日のホワイトリスト判定）と `formatPlanDate`（曜日付き表示への整形）を集約。`stay-minutes.ts`・`visit-time.ts`と同じ、入力検証と表示整形を1箇所に持つ方式。**タイムゾーン非依存**にするため`Date.UTC(...)`と`getUTC*()`のみを使い、ローカル時刻系API（`new Date()`単体、`Date.now()`、`Intl.DateTimeFormat`のtimeZone省略形など）は使わない設計にした。サーバー・クライアントで日付がずれる余地をなくすため。

**日付ピッカーは`Popover` + `Calendar`（shadcn-svelte CLIで新規追加）を組み合わせた`date-picker.svelte`を新設。** 年月日3つの`Select`や`<input type="date">`ではなく、これを選んだ理由は「選んだ日の曜日がひと目で分かる」という要件をUI操作の時点で満たせるのがカレンダーだけだったため。過去日・未来日とも範囲制限はしない（記録用途の入力に「今日」を基準にした制約を持ち込むと、それ自体がタイムゾーン依存を呼び込むため）。

**サーバー側は「ホワイトリスト外は無視してnullに落とす」という既存方針をそのまま踏襲。** 不正な`planDate`（実在しない日・文字列以外の型・XSSペイロード等）が来ても400エラーにはせず、`null`として扱い他の項目は通常どおり処理する。保存前のホワイトリスト判定を通るため、攻撃者が細工した文字列が公開共有ページにそのまま出力されることもない。

**日付をプロンプトに一切注入しないことを、テストで機械的に固定した。** `/api/route`は複数のプロンプト部品を変数で組み立ててから最後に差し込む構造のため、テンプレート文字列だけを見る検証では見落としが起きうる。そこで、`planDate`を渡した場合と渡さない場合とで**リクエストボディ全文が完全一致すること**を検証する形にした。これなら実装がどんな変数名・組み立て方をしても、日付がプロンプトに紛れ込めば必ず検知できる。

## ⚠️ 影響範囲・契約

- `planDate`はすべて任意項目。未指定時のプロンプト・レスポンス・表示・保存は変更なし
- `RouteResult.planDate` / `PlanDraft.planDate`はoptionalで追加（後方互換）。`plans`テーブルは`data`がJSONカラムのためマイグレーション不要
- shadcn-svelte CLIにより`src/lib/components/ui/calendar/`を新規追加（bits-ui・`@internationalized/date`は既存依存の範囲内）。CLI実行の副作用として`@lucide/svelte`が`^1.33.0`→`^1.38.0`に上がった以外の依存変更なし

## ✅ 検証

- `pnpm check` / `pnpm lint` — 0 errors
- `pnpm test:unit --run` — 459 passed（ベースライン390件から新規2ファイル・69件追加）
- `pnpm test:e2e` — 1 passed
- カバレッジ: 既存ファイルの未到達行数がベースラインと完全一致（新規劣化ゼロ）、新規2ファイル（`plan-date.ts` / `date-picker.svelte`）は4指標100%
- 実ブラウザでの動的検証（Playwright、実Gemini API・実DB経由）:
  - 日本語ロケール（曜日ヘッダー・月キャプション）、カレンダーの列と表示曜日の一致
  - キーボードのみでの開閉・日付選択・指定解除・Escape・フォーカス復帰
  - 375px幅での横スクロールなし
  - 敵対的入力7種（XSS・全角数字・末尾改行・型不一致・実在しない日等）でstored XSS不成立、保存自体は常に成功
  - 既存の`planDate`キーを持たない共有プラン3件の非破壊を実SSR経路で確認
  - UI通し動線（`/plan`→作成→結果→もう一度計画する→復元）

このリポジトリのマルチエージェント開発フロー（Planner→Generator→QA）で実装。Sprint ContractはQAが一度差し戻し（プロンプト非注入検証の回避経路、カバレッジ判定の機械的検証可能性など）、Rev.2で条件付き承認。実装完了後の動的QAでも指摘事項ゼロでPASS。詳細は `.dev-loop/20260831-plan-date/`（gitignore対象）を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)